### PR TITLE
Add fast transit-time method, make it default, and fix jacfwd NaN

### DIFF
--- a/src/jnkepler/jaxttv/conversion.py
+++ b/src/jnkepler/jaxttv/conversion.py
@@ -236,26 +236,28 @@ def cm_to_astrocentric(x, v, a, j):
 
 
 def get_acm(x, masses):
-    """compute acceleration given position, velocity, mass
+    """compute acceleration given position, mass
 
-        Args:
-            x: positions in CoM frame (Norbit, xyz)
-            masses: masses of the bodies (Nbody)
+    Args:
+        x: positions in CoM frame (Norbit, xyz)
+        masses: masses of the bodies (Nbody)
 
-        Returns:
-            array: accelerations (Norbit, xyz)
-
+    Returns:
+        array: accelerations in the CoM frame (Norbit, xyz)
     """
-    xjk = jnp.transpose(x[:, None] - x[None, :], axes=[0, 2, 1])
-    x2jk = jnp.sum(xjk * xjk, axis=1)[:, None, :]
-    x2jk = jnp.where(x2jk != 0., x2jk, jnp.inf)
-    x2jkinv = 1. / x2jk
+    xjk = jnp.transpose(x[:, None] - x[None, :], axes=[0, 2, 1])   # (N, 3, N)
+    x2jk = jnp.sum(xjk * xjk, axis=1, keepdims=True)               # (N, 1, N)
 
-    x2jkinv1p5 = x2jkinv * jnp.sqrt(x2jkinv)
-    Xjk = - xjk * x2jkinv1p5
+    mask = ~jnp.eye(x.shape[0], dtype=bool)[:, None, :]            # (N, 1, N)
+
+    # avoid singular values on the diagonal in the differentiated path
+    x2jk_safe = jnp.where(mask, x2jk, 1.0)
+    xjk_safe = jnp.where(mask, xjk, 0.0)
+
+    inv_r3 = x2jk_safe ** (-1.5)
+    Xjk = -xjk_safe * inv_r3
 
     a = G * jnp.dot(Xjk, masses)
-
     return a
 
 

--- a/src/jnkepler/jaxttv/findtransit.py
+++ b/src/jnkepler/jaxttv/findtransit.py
@@ -11,7 +11,7 @@ from jax.lax import scan
 from .conversion import xvjac_to_xvacm, jacobi_to_astrocentric, G
 from .symplectic import kepler_step_map, kick_kepler_map
 from .hermite4 import hermite4_step_map
-from .utils import findidx_map
+from .utils import find_nearest_idx
 config.update('jax_enable_x64', True)
 
 
@@ -52,7 +52,7 @@ def find_tc_idx(t, tcflag, j, tcobs):
 
     """
     tc_candidates = jnp.where(tcflag[:, j], t[1:], -jnp.inf)
-    tcidx = findidx_map(tc_candidates, jnp.atleast_1d(tcobs))
+    tcidx = find_nearest_idx(tc_candidates, jnp.atleast_1d(tcobs))
     return tcidx
 
 

--- a/src/jnkepler/jaxttv/findtransit.py
+++ b/src/jnkepler/jaxttv/findtransit.py
@@ -9,9 +9,9 @@ import jax.numpy as jnp
 from jax import vmap, config, checkpoint
 from jax.lax import scan
 from .conversion import xvjac_to_xvacm, jacobi_to_astrocentric, G
-from .symplectic import kepler_step_map, kick_kepler_map
+from .symplectic import kepler_step_map, kick_kepler_map, kepler_kick_kepler_map
 from .hermite4 import hermite4_step_map
-from .utils import find_nearest_idx
+from .utils import find_nearest_idx, find_nearest_idx_sorted
 config.update('jax_enable_x64', True)
 
 
@@ -132,6 +132,72 @@ def _find_transit_newton_core(pidxarr, tcobsarr, t, xvjac, masses, nitr):
     return tc, xvs
 
 
+def _find_tc_idx_noflag(t, tcobs):
+    """Find indices in ``t[1:]`` nearest to the observed transit times.
+
+    Args:
+        t: Time array of shape ``(Nstep,)``.
+        tcobs: Target transit time or times. A scalar or array-like input
+            is accepted.
+
+    Returns:
+        Indices in ``t[1:]`` nearest to ``tcobs``.
+    """
+    tcidx = find_nearest_idx_sorted(t[1:], jnp.atleast_1d(tcobs))
+    return tcidx
+
+
+def _advance_to_tcobs(tcidx, pidxarr, tcobsarr, t, xvjac, masses):
+    """Advance states to the observed transit times for the fast algorithm."""
+
+    tc = t[1:][tcidx]
+    xvjac_init = xvjac[1:][tcidx]
+
+    # bring back the system by dt/2 so that the systems are at conclusions
+    # of the symplectic step
+    dt_correct = -0.5 * jnp.diff(t)[0]
+    tc += dt_correct
+    xjac_init, vjac_init = kepler_step_map(
+        xvjac_init[:, 0, :, :],
+        xvjac_init[:, 1, :, :],
+        masses,
+        dt_correct,
+    )
+
+    # advance to observed times
+    dt_to_tcobs = tcobsarr - tc
+    xjac_tcobs, vjac_tcobs = kepler_kick_kepler_map(
+        xjac_init,
+        vjac_init,
+        masses,
+        dt_to_tcobs,
+    )
+
+    xcm_tcobs, vcm_tcobs, acm_tcobs = xvjac_to_xvacm(
+        xjac_tcobs, vjac_tcobs, masses)
+    nrstep_tcobs = get_nrstep_map(xcm_tcobs, vcm_tcobs, acm_tcobs, pidxarr)
+
+    return tcobsarr, xcm_tcobs, vcm_tcobs, nrstep_tcobs
+
+
+def _find_transit_time_fast_core(pidxarr, tcobsarr, t, xvjac, masses):
+    tcidx = _find_tc_idx_noflag(t, tcobsarr)
+    tcobs, _, _, nrstep_tcobs = _advance_to_tcobs(
+        tcidx, pidxarr, tcobsarr, t, xvjac, masses)
+    return tcobs + nrstep_tcobs
+
+
+def _find_transit_params_fast_core(pidxarr, tcobsarr, t, xvjac, masses):
+    tcidx = _find_tc_idx_noflag(t, tcobsarr)
+    tcobs, xcm_tcobs, vcm_tcobs, nrstep_tcobs = _advance_to_tcobs(
+        tcidx, pidxarr, tcobsarr, t, xvjac, masses)
+    xcm_tc, vcm_tc, _ = hermite4_step_map(
+        xcm_tcobs, vcm_tcobs, masses, nrstep_tcobs)
+    xcm_tc = jnp.transpose(xcm_tc, axes=[2, 0, 1])
+    vcm_tc = jnp.transpose(vcm_tc, axes=[2, 0, 1])
+    return tcobs + nrstep_tcobs, (xcm_tc, vcm_tc, nrstep_tcobs)
+
+
 def find_transit_times_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=5):
     """find transit times for all planets
 
@@ -149,6 +215,24 @@ def find_transit_times_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=5):
     """
     tc, _ = _find_transit_newton_core(
         pidxarr, tcobsarr, t, xvjac, masses, nitr)
+    return tc
+
+
+def find_transit_times_fast(pidxarr, tcobsarr, t, xvjac, masses):
+    """find transit times for all planets using fast algorithm
+
+        Args:
+            pidxarr: array of orbit index starting from 0 (Ntransit,)
+            tcobsarray: flattened array of observed transit times (Ntransit,)
+            t: times (Nstep,)
+            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
+            masses: masses of the bodies (Nbody,)
+
+        Returns:
+            transit times (1D flattened array)
+
+    """
+    tc = _find_transit_time_fast_core(pidxarr, tcobsarr, t, xvjac, masses)
     return tc
 
 
@@ -170,6 +254,25 @@ def find_transit_params_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=5):
 
     """
     return _find_transit_newton_core(pidxarr, tcobsarr, t, xvjac, masses, nitr)
+
+
+def find_transit_params_fast(pidxarr, tcobsarr, t, xvjac, masses):
+    """find transit times and phase-space coordinates for all planets using fast algorithm
+
+        Args:
+            pidxarr: array of orbit index starting from 0 (Ntransit,)
+            tcobsarray: flattened array of observed transit times (Ntransit,)
+            t: times (Nstep,)
+            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
+            masses: masses of the bodies (Nbody,)
+
+        Returns:
+            tuple:
+                - transit times (1D flattened array)
+                - positions, velocities, and NR step after the last iteration
+
+    """
+    return _find_transit_params_fast_core(pidxarr, tcobsarr, t, xvjac, masses)
 
 
 """ TTVFast algorithm """

--- a/src/jnkepler/jaxttv/findtransit.py
+++ b/src/jnkepler/jaxttv/findtransit.py
@@ -1,121 +1,130 @@
-"""Routines for finding transit times.
-"""
+"""Routines for finding transit times."""
+
 __all__ = [
-    "find_transit_times_all", "find_transit_params_all",
-    "find_transit_times_kepler_all"
+    "find_transit_times_all",
+    "find_transit_times_fast",
+    "find_transit_params_all",
+    "find_transit_params_fast",
+    "find_transit_times_kepler_all",
 ]
 
 import jax.numpy as jnp
-from jax import vmap, config, checkpoint
+from jax import checkpoint, config, vmap
 from jax.lax import scan
-from .conversion import xvjac_to_xvacm, jacobi_to_astrocentric, G
-from .symplectic import kepler_step_map, kick_kepler_map, kepler_kick_kepler_map
+
+from .conversion import G, jacobi_to_astrocentric, xvjac_to_xvacm
 from .hermite4 import hermite4_step_map
+from .symplectic import kepler_kick_kepler_map, kepler_step_map, kick_kepler_map
 from .utils import find_nearest_idx, find_nearest_idx_sorted
-config.update('jax_enable_x64', True)
+
+config.update("jax_enable_x64", True)
 
 
-def get_tcflag(xjac, vjac):
-    """find times just after the transit centers using *Jacobi* coordinates
+def _get_tcflag(xjac, vjac):
+    """Find steps just after transit centers using Jacobi coordinates.
 
-        Args:
-            xjac: jacobi positions (Nstep, Norbit, xyz)
-            vjac: jacobi velocities (Nstep, Norbit, xyz)
+    Args:
+        xjac: Jacobi positions of shape ``(Nstep, Norbit, 3)``.
+        vjac: Jacobi velocities of shape ``(Nstep, Norbit, 3)``.
 
-        Returns:
-            array (bool): True if the time is just after the transit center (Nstep-1,)
-
+    Returns:
+        Boolean array of shape ``(Nstep - 1, Norbit)`` whose entries are
+        True at steps just after the transit center.
     """
-    g = jnp.sum(xjac[:, :, :2] * vjac[:, :, :2], axis=2)  # Nstep, Norbit
-    tcflag = (g[:-1] < 0) & (g[1:] > 0) & (xjac[1:, :, 2] > 0)
-    return tcflag
+    g = jnp.sum(xjac[:, :, :2] * vjac[:, :, :2], axis=2)
+    return (g[:-1] < 0.0) & (g[1:] > 0.0) & (xjac[1:, :, 2] > 0.0)
 
 
-def get_g_map(xjac, vjac, pidxarr):
-    def g_orbit(xjac, vjac, j):
-        return jnp.sum(xjac[j, :2] * vjac[j, :2])
+def _get_g_map(xjac, vjac, pidxarr):
+    """Evaluate ``x · v`` in the sky plane for the selected planets."""
+
+    def g_orbit(xjac_one, vjac_one, j):
+        return jnp.sum(xjac_one[j, :2] * vjac_one[j, :2])
+
     g_map = vmap(g_orbit, (0, 0, 0), 0)
     return g_map(xjac, vjac, pidxarr).ravel()
 
 
-def find_tc_idx(t, tcflag, j, tcobs):
-    """find indices for times where tcflag is True
+def _find_tc_idx(t, tcflag, j, tcobs):
+    """Find candidate-step indices nearest to the target transit times.
 
-        Args:
-            t: times (Nstep,)
-            tcflag: True if the time is just after the transit center (Nstep-1,)
-            j: orbit (planet) index
-            tcobs: transit times for jth orbit (planet)
+    Args:
+        t: Time array of shape ``(Nstep,)``.
+        tcflag: Boolean array of shape ``(Nstep - 1, Norbit)`` indicating
+            whether each step is just after a transit center.
+        j: Orbit index.
+        tcobs: Target transit time or times for the selected orbit.
 
-        Returns:
-            array: indices of times cloeset to transit centers (Nstep-1,); should be put into times[1:], x[1:], etc.
-
+    Returns:
+        Indices in ``t[1:]`` closest to ``tcobs`` among the entries where
+        ``tcflag[:, j]`` is True.
     """
     tc_candidates = jnp.where(tcflag[:, j], t[1:], -jnp.inf)
-    tcidx = find_nearest_idx(tc_candidates, jnp.atleast_1d(tcobs))
-    return tcidx
+    return find_nearest_idx(tc_candidates, jnp.atleast_1d(tcobs))
 
 
-# map along the transit axis
-find_tc_idx_map = vmap(find_tc_idx, (None, None, 0, 0), 0)
+_find_tc_idx_map = vmap(_find_tc_idx, (None, None, 0, 0), 0)
 
 
-def get_nrstep(x, v, a, j):
-    """compute NR step for jth orbit (planet)
+def _get_nrstep(x, v, a, j):
+    """Compute one Newton correction step for the selected planet.
 
-        Args:
-            x: positions in CM frame (Norbit, xyz)
-            v: velocities in CM frame (Norbit, xyz)
-            a: accels in CM frame (Norbit, xyz)
-            j: orbit (planet) index, starting from 0
+    Args:
+        x: Positions in the center-of-mass frame of shape ``(Nbody, 3)``.
+        v: Velocities in the center-of-mass frame of shape ``(Nbody, 3)``.
+        a: Accelerations in the center-of-mass frame of shape ``(Nbody, 3)``.
+        j: Orbit index starting from 0.
 
-        Returns:
-            NR step for jth orbit (planet)
-
+    Returns:
+        Newton correction step for the selected planet.
     """
-    xastj = x[j+1, :] - x[0, :]
-    vastj = v[j+1, :] - v[0, :]
-    aastj = a[j+1, :] - a[0, :]
+    xastj = x[j + 1, :] - x[0, :]
+    vastj = v[j + 1, :] - v[0, :]
+    aastj = a[j + 1, :] - a[0, :]
     gj = jnp.sum(xastj[:2] * vastj[:2])
     dotgj = jnp.sum(vastj[:2] * vastj[:2]) + jnp.sum(xastj[:2] * aastj[:2])
-    stepj = - gj / dotgj
-    return stepj
+    return -gj / dotgj
 
 
-# map along the transit axis
-get_nrstep_map = vmap(get_nrstep, (0, 0, 0, 0), 0)
+_get_nrstep_map = vmap(_get_nrstep, (0, 0, 0, 0), 0)
 
 
 def _find_transit_candidates(pidxarr, tcobsarr, t, xvjac):
+    """Find integration steps nearest to the target transit times."""
     xjac, vjac = xvjac[:, 0, :, :], xvjac[:, 1, :, :]
-    tcflag = get_tcflag(xjac, vjac)
-    return find_tc_idx_map(t, tcflag, pidxarr, tcobsarr).ravel()
+    tcflag = _get_tcflag(xjac, vjac)
+    return _find_tc_idx_map(t, tcflag, pidxarr, tcobsarr).ravel()
 
 
-def _prepare_transit_init(tcidx, pidxarr, t, xvjac, masses):
+def _prepare_transit_newton_init(tcidx, pidxarr, t, xvjac, masses):
+    """Prepare initial states for Newton refinement."""
     tc = t[1:][tcidx]
     xvjac_init = xvjac[1:][tcidx]
 
-    # bring back the system by dt/2 so that the systems are at conclusions of the symplectic step
+    # Bring back the system by dt/2 so that the states are at the
+    # conclusions of the symplectic step.
     dt_correct = -0.5 * jnp.diff(t)[0]
     tc += dt_correct
     xjac_init, vjac_init = kepler_step_map(
-        xvjac_init[:, 0, :, :], xvjac_init[:, 1, :, :], masses, dt_correct)
+        xvjac_init[:, 0, :, :], xvjac_init[:, 1, :, :], masses, dt_correct
+    )
 
     xcm_init, vcm_init, acm_init = xvjac_to_xvacm(xjac_init, vjac_init, masses)
-    nrstep_init = get_nrstep_map(xcm_init, vcm_init, acm_init, pidxarr)
+    nrstep_init = _get_nrstep_map(xcm_init, vcm_init, acm_init, pidxarr)
 
     return tc, xcm_init, vcm_init, nrstep_init
 
 
 def _scan_transit_newton(xcm_init, vcm_init, nrstep_init, pidxarr, masses, nitr):
-    def tcstep(xvs, i):
+    """Run Newton refinement for the transit times."""
+
+    def tcstep(xvs, _):
         xin, vin, step = xvs
         xtc, vtc, atc = hermite4_step_map(xin, vin, masses, step)
         xtc = jnp.transpose(xtc, axes=[2, 0, 1])
         vtc = jnp.transpose(vtc, axes=[2, 0, 1])
         atc = jnp.transpose(atc, axes=[2, 0, 1])
-        step = get_nrstep_map(xtc, vtc, atc, pidxarr)
+        step = _get_nrstep_map(xtc, vtc, atc, pidxarr)
         return (xtc, vtc, step), step
 
     tcstep = checkpoint(tcstep)
@@ -123,38 +132,56 @@ def _scan_transit_newton(xcm_init, vcm_init, nrstep_init, pidxarr, masses, nitr)
 
 
 def _find_transit_newton_core(pidxarr, tcobsarr, t, xvjac, masses, nitr):
+    """Core Newton-based transit finder."""
     tcidx = _find_transit_candidates(pidxarr, tcobsarr, t, xvjac)
-    tc, xcm_init, vcm_init, nrstep_init = _prepare_transit_init(
-        tcidx, pidxarr, t, xvjac, masses)
+    tc, xcm_init, vcm_init, nrstep_init = _prepare_transit_newton_init(
+        tcidx, pidxarr, t, xvjac, masses
+    )
     xvs, steps = _scan_transit_newton(
-        xcm_init, vcm_init, nrstep_init, pidxarr, masses, nitr)
+        xcm_init, vcm_init, nrstep_init, pidxarr, masses, nitr
+    )
     tc += nrstep_init + jnp.sum(steps, axis=0)
     return tc, xvs
 
 
-def _find_tc_idx_noflag(t, tcobs):
-    """Find indices in ``t[1:]`` nearest to the observed transit times.
+def _find_tc_idx_sorted(t, tcobs):
+    """Find indices in ``t[1:]`` nearest to the target transit times.
 
     Args:
         t: Time array of shape ``(Nstep,)``.
-        tcobs: Target transit time or times. A scalar or array-like input
-            is accepted.
+        tcobs: Target transit time or times. A scalar or array-like input is
+            accepted.
 
     Returns:
         Indices in ``t[1:]`` nearest to ``tcobs``.
     """
-    tcidx = find_nearest_idx_sorted(t[1:], jnp.atleast_1d(tcobs))
-    return tcidx
+    return find_nearest_idx_sorted(t[1:], jnp.atleast_1d(tcobs))
 
 
-def _advance_to_tcobs(tcidx, pidxarr, tcobsarr, t, xvjac, masses):
-    """Advance states to the observed transit times for the fast algorithm."""
+def _advance_to_tcobs_fast(tcidx, pidxarr, tcobsarr, t, xvjac, masses):
+    """Advance states to ``tcobsarr`` for the fast transit finder.
 
+    Args:
+        tcidx: Indices in ``t[1:]`` nearest to ``tcobsarr``.
+        pidxarr: Planet indices corresponding to each transit.
+        tcobsarr: Observed transit times.
+        t: Time array of shape ``(Nstep,)``.
+        xvjac: Jacobi-frame positions and velocities of shape
+            ``(Nstep, 2, Norbit, 3)``.
+        masses: Mass array of shape ``(Nbody,)``.
+
+    Returns:
+        Tuple containing
+            - the observed transit times,
+            - positions in the center-of-mass frame at ``tcobsarr``,
+            - velocities in the center-of-mass frame at ``tcobsarr``, and
+            - the transit-time correction evaluated at ``tcobsarr``.
+    """
     tc = t[1:][tcidx]
     xvjac_init = xvjac[1:][tcidx]
 
-    # bring back the system by dt/2 so that the systems are at conclusions
-    # of the symplectic step
+    # Bring back the system by dt/2 so that the states are at the
+    # conclusions of the symplectic step.
     dt_correct = -0.5 * jnp.diff(t)[0]
     tc += dt_correct
     xjac_init, vjac_init = kepler_step_map(
@@ -164,7 +191,7 @@ def _advance_to_tcobs(tcidx, pidxarr, tcobsarr, t, xvjac, masses):
         dt_correct,
     )
 
-    # advance to observed times
+    # Advance from the step boundary to the observed transit times.
     dt_to_tcobs = tcobsarr - tc
     xjac_tcobs, vjac_tcobs = kepler_kick_kepler_map(
         xjac_init,
@@ -174,23 +201,28 @@ def _advance_to_tcobs(tcidx, pidxarr, tcobsarr, t, xvjac, masses):
     )
 
     xcm_tcobs, vcm_tcobs, acm_tcobs = xvjac_to_xvacm(
-        xjac_tcobs, vjac_tcobs, masses)
-    nrstep_tcobs = get_nrstep_map(xcm_tcobs, vcm_tcobs, acm_tcobs, pidxarr)
+        xjac_tcobs, vjac_tcobs, masses
+    )
+    nrstep_tcobs = _get_nrstep_map(xcm_tcobs, vcm_tcobs, acm_tcobs, pidxarr)
 
     return tcobsarr, xcm_tcobs, vcm_tcobs, nrstep_tcobs
 
 
-def _find_transit_time_fast_core(pidxarr, tcobsarr, t, xvjac, masses):
-    tcidx = _find_tc_idx_noflag(t, tcobsarr)
-    tcobs, _, _, nrstep_tcobs = _advance_to_tcobs(
-        tcidx, pidxarr, tcobsarr, t, xvjac, masses)
+def _find_transit_times_fast_core(pidxarr, tcobsarr, t, xvjac, masses):
+    """Core fast transit finder returning only transit times."""
+    tcidx = _find_tc_idx_sorted(t, tcobsarr)
+    tcobs, _, _, nrstep_tcobs = _advance_to_tcobs_fast(
+        tcidx, pidxarr, tcobsarr, t, xvjac, masses
+    )
     return tcobs + nrstep_tcobs
 
 
 def _find_transit_params_fast_core(pidxarr, tcobsarr, t, xvjac, masses):
-    tcidx = _find_tc_idx_noflag(t, tcobsarr)
-    tcobs, xcm_tcobs, vcm_tcobs, nrstep_tcobs = _advance_to_tcobs(
-        tcidx, pidxarr, tcobsarr, t, xvjac, masses)
+    """Core fast transit finder returning transit times and phase-space states."""
+    tcidx = _find_tc_idx_sorted(t, tcobsarr)
+    tcobs, xcm_tcobs, vcm_tcobs, nrstep_tcobs = _advance_to_tcobs_fast(
+        tcidx, pidxarr, tcobsarr, t, xvjac, masses
+    )
     xcm_tc, vcm_tc, _ = hermite4_step_map(
         xcm_tcobs, vcm_tcobs, masses, nrstep_tcobs)
     xcm_tc = jnp.transpose(xcm_tc, axes=[2, 0, 1])
@@ -199,19 +231,20 @@ def _find_transit_params_fast_core(pidxarr, tcobsarr, t, xvjac, masses):
 
 
 def find_transit_times_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=5):
-    """find transit times for all planets
+    """Find transit times for all requested transits using Newton refinement.
 
-        Args:
-            pidxarr: array of orbit index starting from 0 (Ntransit,)
-            tcobsarray: flattened array of observed transit times (Ntransit,)
-            t: times (Nstep,)
-            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
-            masses: masses of the bodies (Nbody,)
-            nitr: number of Newton-Raphson iterations
+    Args:
+        pidxarr: Orbit indices starting from 0, with shape ``(Ntransit,)``.
+        tcobsarr: Flattened array of observed transit times of shape
+            ``(Ntransit,)``.
+        t: Time array of shape ``(Nstep,)``.
+        xvjac: Jacobi positions and velocities of shape
+            ``(Nstep, 2, Norbit, 3)``.
+        masses: Mass array of shape ``(Nbody,)``.
+        nitr: Number of Newton-Raphson iterations.
 
-        Returns:
-            transit times (1D flattened array)
-
+    Returns:
+        Transit times as a one-dimensional array.
     """
     tc, _ = _find_transit_newton_core(
         pidxarr, tcobsarr, t, xvjac, masses, nitr)
@@ -219,134 +252,143 @@ def find_transit_times_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=5):
 
 
 def find_transit_times_fast(pidxarr, tcobsarr, t, xvjac, masses):
-    """find transit times for all planets using fast algorithm
+    """Find transit times for all requested transits using the fast algorithm.
 
-        Args:
-            pidxarr: array of orbit index starting from 0 (Ntransit,)
-            tcobsarray: flattened array of observed transit times (Ntransit,)
-            t: times (Nstep,)
-            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
-            masses: masses of the bodies (Nbody,)
+    Args:
+        pidxarr: Orbit indices starting from 0, with shape ``(Ntransit,)``.
+        tcobsarr: Flattened array of observed transit times of shape
+            ``(Ntransit,)``.
+        t: Time array of shape ``(Nstep,)``.
+        xvjac: Jacobi positions and velocities of shape
+            ``(Nstep, 2, Norbit, 3)``.
+        masses: Mass array of shape ``(Nbody,)``.
 
-        Returns:
-            transit times (1D flattened array)
-
+    Returns:
+        Transit times as a one-dimensional array.
     """
-    tc = _find_transit_time_fast_core(pidxarr, tcobsarr, t, xvjac, masses)
-    return tc
+    return _find_transit_times_fast_core(pidxarr, tcobsarr, t, xvjac, masses)
 
 
 def find_transit_params_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=5):
-    """find transit times and phase-space coordinates for all planets
+    """Find transit times and phase-space states using Newton refinement.
 
-        Args:
-            pidxarr: array of orbit index starting from 0 (Ntransit,)
-            tcobsarray: flattened array of observed transit times (Ntransit,)
-            t: times (Nstep,)
-            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
-            masses: masses of the bodies (Nbody,)
-            nitr: number of Newton-Raphson iterations
+    Args:
+        pidxarr: Orbit indices starting from 0, with shape ``(Ntransit,)``.
+        tcobsarr: Flattened array of observed transit times of shape
+            ``(Ntransit,)``.
+        t: Time array of shape ``(Nstep,)``.
+        xvjac: Jacobi positions and velocities of shape
+            ``(Nstep, 2, Norbit, 3)``.
+        masses: Mass array of shape ``(Nbody,)``.
+        nitr: Number of Newton-Raphson iterations.
 
-        Returns:
-            tuple:
-                - transit times (1D flattened array)
-                - positions, velocities, and NR step after the last iteration
-
+    Returns:
+        Tuple containing
+            - transit times as a one-dimensional array, and
+            - positions, velocities, and Newton steps from the final iteration.
     """
     return _find_transit_newton_core(pidxarr, tcobsarr, t, xvjac, masses, nitr)
 
 
 def find_transit_params_fast(pidxarr, tcobsarr, t, xvjac, masses):
-    """find transit times and phase-space coordinates for all planets using fast algorithm
+    """Find transit times and phase-space states using the fast algorithm.
 
-        Args:
-            pidxarr: array of orbit index starting from 0 (Ntransit,)
-            tcobsarray: flattened array of observed transit times (Ntransit,)
-            t: times (Nstep,)
-            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
-            masses: masses of the bodies (Nbody,)
+    Args:
+        pidxarr: Orbit indices starting from 0, with shape ``(Ntransit,)``.
+        tcobsarr: Flattened array of observed transit times of shape
+            ``(Ntransit,)``.
+        t: Time array of shape ``(Nstep,)``.
+        xvjac: Jacobi positions and velocities of shape
+            ``(Nstep, 2, Norbit, 3)``.
+        masses: Mass array of shape ``(Nbody,)``.
 
-        Returns:
-            tuple:
-                - transit times (1D flattened array)
-                - positions, velocities, and NR step after the last iteration
-
+    Returns:
+        Tuple containing
+            - transit times as a one-dimensional array, and
+            - positions, velocities, and the time corrections evaluated at
+              ``tcobsarr``.
     """
     return _find_transit_params_fast_core(pidxarr, tcobsarr, t, xvjac, masses)
 
 
-""" TTVFast algorithm """
+"""TTVFast algorithm."""
 
 
-def get_elements(x, v, gm):
-    """get elements
+def _get_elements(x, v, gm):
+    """Compute orbital quantities used by the TTVFast interpolation step.
 
-        Args:
-            x: positions (Norbit, xyz)
-            v: velocities (Norbit, xyz)
-            gm: 'GM' in Kepler's 3rd law
+    Args:
+        x: Positions of shape ``(Norbit, 3)``.
+        v: Velocities of shape ``(Norbit, 3)``.
+        gm: ``GM`` for each orbit.
 
-        Returns:
-            tuple:
-                - n: mean motion
-                - ecosE0, esinE0: eccentricity and eccentric anomaly
-                - a/r0: semi-major axis divided by |x|
-
+    Returns:
+        Tuple containing the mean motion, ``e cos E0``, ``e sin E0``, and
+        ``a / r0``.
     """
-    r0 = jnp.sqrt(jnp.sum(x*x, axis=1))
-    v0s = jnp.sum(v*v, axis=1)
-    u = jnp.sum(x*v, axis=1)
-    a = 1. / (2./r0 - v0s/gm)
+    r0 = jnp.sqrt(jnp.sum(x * x, axis=1))
+    v0s = jnp.sum(v * v, axis=1)
+    u = jnp.sum(x * v, axis=1)
+    a = 1.0 / (2.0 / r0 - v0s / gm)
 
-    n = jnp.sqrt(gm / (a*a*a))
-    ecosE0, esinE0 = 1. - r0 / a, u / (n*a*a)
+    n = jnp.sqrt(gm / (a * a * a))
+    ecosE0, esinE0 = 1.0 - r0 / a, u / (n * a * a)
 
-    return n, ecosE0, esinE0, a/r0
+    return n, ecosE0, esinE0, a / r0
 
 
-def find_transit_times_kepler(xast, vast, kast, dt, nitr):
-    """find transit times via interpolation
+def _find_transit_times_kepler(xast, vast, kast, dt, nitr):
+    """Find transit times via the TTVFast interpolation scheme.
 
-        Note:
-            This function is adapted from TTVFast https://github.com/kdeck/TTVFast, original scheme developed by Nesvorny et al. (2013, ApJ 777,3)
+    Note:
+        This function is adapted from TTVFast
+        https://github.com/kdeck/TTVFast, based on the scheme developed by
+        Nesvorny et al. (2013, ApJ, 777, 3).
 
-        Args:
-            xast: astrocentric positions (Norbit, xyz)
-            vast: astrocentric velocities (Norbit, xyz)
-            kast: astrocentric GM
-            dt: integration time step
+    Args:
+        xast: Astrocentric positions of shape ``(Norbit, 3)``.
+        vast: Astrocentric velocities of shape ``(Norbit, 3)``.
+        kast: Astrocentric ``GM``.
+        dt: Integration time step.
+        nitr: Number of iterations used in the interpolation solve.
 
-        Returns:
-            time to the transit center
-
+    Returns:
+        Time to the transit center.
     """
-    n, ecosE0, esinE0, a_r0 = get_elements(xast, vast, kast)
-    rsquared = jnp.sum(xast[:, :2]*xast[:, :2], axis=1)
-    vsquared = jnp.sum(vast[:, :2]*vast[:, :2], axis=1)
-    xdotv = jnp.sum(xast[:, :2]*vast[:, :2], axis=1)
+    n, ecosE0, esinE0, a_r0 = _get_elements(xast, vast, kast)
+    rsquared = jnp.sum(xast[:, :2] * xast[:, :2], axis=1)
+    vsquared = jnp.sum(vast[:, :2] * vast[:, :2], axis=1)
+    xdotv = jnp.sum(xast[:, :2] * vast[:, :2], axis=1)
 
-    def dEstep_transit(dE, i):
+    def dEstep_transit(dE, _):
         x2 = dE / 2.0
         sx2, cx2 = jnp.sin(x2), jnp.cos(x2)
-        f = 1.0 - a_r0*2.0*sx2*sx2
-        sx, cx = 2.0*sx2*cx2, cx2*cx2 - sx2*sx2
-        g = (2.0*sx2*(esinE0*sx2 + cx2/a_r0))/n
-        fp = 1.0 - cx*ecosE0 + sx*esinE0
-        fdot = -(a_r0/fp)*n*sx
-        fp2 = sx*ecosE0 + cx*esinE0
-        gdot = 1.0-2.0*sx2*sx2/fp
+        f = 1.0 - a_r0 * 2.0 * sx2 * sx2
+        sx, cx = 2.0 * sx2 * cx2, cx2 * cx2 - sx2 * sx2
+        g = (2.0 * sx2 * (esinE0 * sx2 + cx2 / a_r0)) / n
+        fp = 1.0 - cx * ecosE0 + sx * esinE0
+        fdot = -(a_r0 / fp) * n * sx
+        fp2 = sx * ecosE0 + cx * esinE0
+        gdot = 1.0 - 2.0 * sx2 * sx2 / fp
 
-        dgdotdz = -sx/fp+2.0*sx2*sx2/fp/fp*fp2
-        dfdz = -a_r0*sx
-        dgdz = 1.0/n*(sx*esinE0-(ecosE0-1.0)*cx)
-        dfdotdz = -n*a_r0/fp*(cx+sx/fp*fp2)
+        dgdotdz = -sx / fp + 2.0 * sx2 * sx2 / fp / fp * fp2
+        dfdz = -a_r0 * sx
+        dgdz = (sx * esinE0 - (ecosE0 - 1.0) * cx) / n
+        dfdotdz = -n * a_r0 / fp * (cx + sx / fp * fp2)
 
-        dotproduct = f*fdot*(rsquared)+g*gdot*(vsquared) + \
-            (f*gdot+g*fdot)*(xdotv)
-        dotproductderiv = dfdz*(gdot*xdotv+fdot*rsquared)+dfdotdz*(
-            f*rsquared+g*xdotv)+dgdz*(fdot*xdotv+gdot*vsquared)+dgdotdz*(g*vsquared+f*xdotv)
+        dotproduct = (
+            f * fdot * rsquared
+            + g * gdot * vsquared
+            + (f * gdot + g * fdot) * xdotv
+        )
+        dotproductderiv = (
+            dfdz * (gdot * xdotv + fdot * rsquared)
+            + dfdotdz * (f * rsquared + g * xdotv)
+            + dgdz * (fdot * xdotv + gdot * vsquared)
+            + dgdotdz * (g * vsquared + f * xdotv)
+        )
 
-        return dE - dotproduct/dotproductderiv, None
+        return dE - dotproduct / dotproductderiv, None
 
     dE0 = n * dt / 2.0
     dE, _ = scan(dEstep_transit, dE0, jnp.arange(nitr))
@@ -358,56 +400,66 @@ def find_transit_times_kepler(xast, vast, kast, dt, nitr):
     return transitM / n
 
 
-# map along the transit axis
-find_transit_times_kepler_map = vmap(
-    find_transit_times_kepler, (0, 0, 0, None, None), 0)
+_find_transit_times_kepler_map = vmap(
+    _find_transit_times_kepler, (0, 0, 0, None, None), 0
+)
 
 
 def find_transit_times_kepler_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=3):
-    """find transit times for all planets via interpolation
+    """Find transit times via the legacy TTVFast-style interpolation scheme.
 
-        Note:
-            Bug: this function sometimes fails for large dt for reason yet to be understood.
+    Note:
+        This function is kept for backward compatibility and will be deprecated. 
+        It may fail for large ``dt``.
 
-        Args:
-            pidxarr: array of orbit index starting from 0 (Ntransit,)
-            tcobsarray: flattened array of observed transit times (Ntransit,)
-            t: times (Nstep,)
-            xvjac: Jacobi positions and velocities (Nstep, x or v, Norbit, xyz)
-            masses: masses of the bodies (Nbody,)
-            nitr: number of Newton-Raphson iterations
+    Args:
+        pidxarr: Orbit indices starting from 0, with shape ``(Ntransit,)``.
+        tcobsarr: Flattened array of observed transit times of shape
+            ``(Ntransit,)``.
+        t: Time array of shape ``(Nstep,)``.
+        xvjac: Jacobi positions and velocities of shape
+            ``(Nstep, 2, Norbit, 3)``.
+        masses: Mass array of shape ``(Nbody,)``.
+        nitr: Number of iterations used in the Kepler interpolation step.
 
-        Returns:
-            transit times (1D flattened array)
-
+    Returns:
+        Transit times as a one-dimensional array.
     """
     xjac, vjac = xvjac[:, 0, :, :], xvjac[:, 1, :, :]
-    tcflag = get_tcflag(xjac, vjac)
-    tcidx = find_tc_idx_map(t, tcflag, pidxarr, tcobsarr).ravel()
+    tcflag = _get_tcflag(xjac, vjac)
+    tcidx = _find_tc_idx_map(t, tcflag, pidxarr, tcobsarr).ravel()
 
-    tc_ahead, tc_behind = t[1:][tcidx], t[1:][tcidx-1]
-    xvjac_ahead, xvjac_behind = xvjac[1:][tcidx], xvjac[1:][tcidx-1]
+    tc_ahead, tc_behind = t[1:][tcidx], t[1:][tcidx - 1]
+    xvjac_ahead, xvjac_behind = xvjac[1:][tcidx], xvjac[1:][tcidx - 1]
 
-    # bring back the system by dt/2 so that the systems are at conclusions of the symplectic step
-    # if the transit is not bracketed after this shift, advance the system by dt again
+    # Bring back the system by dt/2 so that the states are at the
+    # conclusions of the symplectic step. If the transit is not bracketed
+    # after this shift, advance the system by dt again.
     dt = jnp.diff(t)[0]
     dt2 = 0.5 * dt
     xjac_ahead_mindt2, vjac_ahead_mindt2 = kepler_step_map(
-        xvjac_ahead[:, 0, :, :], xvjac_ahead[:, 1, :, :], masses, -dt2)
+        xvjac_ahead[:, 0, :, :], xvjac_ahead[:, 1, :, :], masses, -dt2
+    )
     xjac_behind_mindt2, vjac_behind_mindt2 = kepler_step_map(
-        xvjac_behind[:, 0, :, :], xvjac_behind[:, 1, :, :], masses, -dt2)
+        xvjac_behind[:, 0, :, :], xvjac_behind[:, 1, :, :], masses, -dt2
+    )
     xjac_ahead_plusdt2, vjac_ahead_plusdt2 = kick_kepler_map(
-        xvjac_ahead[:, 0, :, :], xvjac_ahead[:, 1, :, :], masses, dt2)
-    tcflag_mindt2 = get_g_map(xjac_ahead_mindt2, vjac_ahead_mindt2,
-                              pidxarr) > 0.  # True if still bracketing the transit
+        xvjac_ahead[:, 0, :, :], xvjac_ahead[:, 1, :, :], masses, dt2
+    )
+    tcflag_mindt2 = _get_g_map(
+        xjac_ahead_mindt2, vjac_ahead_mindt2, pidxarr) > 0.0
 
-    def func(x, y, z): return jnp.where(x, y, z)
-    func_map = vmap(func, (0, 0, 0), 0)
-    xjac_ahead = func_map(tcflag_mindt2, xjac_ahead_mindt2, xjac_ahead_plusdt2)
-    xjac_behind = func_map(
+    def _select(mask, left, right):
+        return jnp.where(mask, left, right)
+
+    select_map = vmap(_select, (0, 0, 0), 0)
+    xjac_ahead = select_map(
+        tcflag_mindt2, xjac_ahead_mindt2, xjac_ahead_plusdt2)
+    xjac_behind = select_map(
         tcflag_mindt2, xjac_behind_mindt2, xjac_ahead_mindt2)
-    vjac_ahead = func_map(tcflag_mindt2, vjac_ahead_mindt2, vjac_ahead_plusdt2)
-    vjac_behind = func_map(
+    vjac_ahead = select_map(
+        tcflag_mindt2, vjac_ahead_mindt2, vjac_ahead_plusdt2)
+    vjac_behind = select_map(
         tcflag_mindt2, vjac_behind_mindt2, vjac_ahead_mindt2)
     tc_ahead = jnp.where(tcflag_mindt2, tc_ahead - dt2, tc_ahead + dt2)
     tc_behind = jnp.where(tcflag_mindt2, tc_behind - dt2, tc_behind + dt2)
@@ -420,12 +472,18 @@ def find_transit_times_kepler_all(pidxarr, tcobsarr, t, xvjac, masses, nitr=3):
     kast = G * (masses[1:] + masses[0])
     kastarr = kast[pidxarr]
 
-    tau_ahead = tc_ahead + jnp.diag(find_transit_times_kepler_map(
-        xast_ahead, vast_ahead, kastarr, -dt, nitr)[:, pidxarr])
-    tau_behind = tc_behind + jnp.diag(find_transit_times_kepler_map(
-        xast_behind, vast_behind, kastarr, dt, nitr)[:, pidxarr])
+    tau_ahead = tc_ahead + jnp.diag(
+        _find_transit_times_kepler_map(
+            xast_ahead, vast_ahead, kastarr, -dt, nitr)[:, pidxarr]
+    )
+    tau_behind = tc_behind + jnp.diag(
+        _find_transit_times_kepler_map(
+            xast_behind, vast_behind, kastarr, dt, nitr)[:, pidxarr]
+    )
 
-    tc = ((tau_behind - tc_behind) * tau_ahead + (tc_ahead - tau_ahead)
-          * tau_behind) / (dt + tau_behind - tau_ahead)
+    tc = (
+        (tau_behind - tc_behind) * tau_ahead
+        + (tc_ahead - tau_ahead) * tau_behind
+    ) / (dt + tau_behind - tau_ahead)
 
     return tc

--- a/src/jnkepler/jaxttv/jaxttv.py
+++ b/src/jnkepler/jaxttv/jaxttv.py
@@ -10,7 +10,11 @@ from functools import partial
 from copy import deepcopy
 from .utils import *
 from .conversion import *
-from .findtransit import find_transit_times_all, find_transit_times_kepler_all
+from .findtransit import (
+    find_transit_times_all,
+    find_transit_times_fast,
+    find_transit_times_kepler_all,
+)
 from .symplectic import integrate_xv, kepler_step_map
 from .hermite4 import integrate_xv as integrate_xv_hermite4
 from .rv import *
@@ -42,7 +46,59 @@ class Nbody:
 class JaxTTV(Nbody):
     """main class for TTV analysis"""
 
-    def __init__(self, t_start, t_end, dt, tcobs, p_init, errorobs=None, print_info=True, nitr_kepler=10, transit_time_method='newton-raphson', nitr_transit=5):
+    @property
+    def transit_time_method(self):
+        """Transit-time algorithm used for observed transits."""
+        return self._transit_time_method
+
+    @transit_time_method.setter
+    def transit_time_method(self, method):
+        """Set and canonicalize the transit-time algorithm name."""
+        if method == "newton-raphson":
+            warnings.warn(
+                "'newton-raphson' is deprecated; use 'newton' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            method = "newton"
+        elif method == "interpolation":
+            warnings.warn(
+                "'interpolation' is deprecated; use 'kepler' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            method = "kepler"
+
+        if method not in ("fast", "newton", "kepler"):
+            raise ValueError(
+                "transit_time_method must be one of 'fast', 'newton', or 'kepler'."
+            )
+
+        if method == "kepler":
+            warnings.warn(
+                "transit_time_method='kepler' is kept for backward compatibility "
+                "and is not well tested."
+            )
+
+        self._transit_time_method = method
+
+    def _compute_transit_times(self, orbit_idx, tcobs1d, times, xvjac, masses, method=None):
+        """Dispatch transit-time computation to the requested algorithm."""
+        if method is None:
+            method = self.transit_time_method
+
+        if method == 'newton':
+            return find_transit_times_all(
+                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_transit)
+        if method == 'fast':
+            return find_transit_times_fast(
+                orbit_idx, tcobs1d, times, xvjac, masses)
+        if method == 'kepler':
+            return find_transit_times_kepler_all(
+                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_kepler)
+        raise ValueError(f"Unsupported transit_time_method: {method}")
+
+    def __init__(self, t_start, t_end, dt, tcobs, p_init, errorobs=None, print_info=True, nitr_kepler=10, transit_time_method='fast', nitr_transit=5):
         """initialization
 
             Args:
@@ -50,12 +106,18 @@ class JaxTTV(Nbody):
                 t_end: end time of integration
                 dt: integration time step (day)
                 nitr_kepler: number of iterations in Kepler steps
-                transit_time_method: Newton-Raphson or interpolation (latter not fully tested)
-                nitr_transit: number of iterations in transit-finding loop (only for Newton-Raphson)
+                transit_time_method: algorithm used for transit-time computation.
+                    Supported values are ``"fast"`` (default), ``"newton"``,
+                    and ``"kepler"``. Legacy aliases ``"newton-raphson"``
+                    and ``"interpolation"`` are also accepted.
+                nitr_transit: number of iterations in the Newton transit-finding
+                    loop (used only for the Newton method)
 
             Attributes:
-                transit_time_method: algorithm for transit time computation 
-                nit_transit: number of Newton-Raphson iterations in computing transit times
+                transit_time_method: algorithm for transit-time computation for
+                    observed transits
+                nitr_transit: number of Newton iterations in transit-time
+                    computation
                 nplanet: number of transiting planets
                 p_init: initial guess for mean orbital periods for tracking transit epochs
                 tcobs: list of observed transit time arrays
@@ -72,9 +134,6 @@ class JaxTTV(Nbody):
         tcobs, tcobs_flatten, nplanet, p_init, errorobs, errorobs_flatten, pidx, tcobs_linear \
             = self.set_tcobs(tcobs, p_init, errorobs=errorobs, print_info=print_info)
 
-        if transit_time_method != "newton-raphson":
-            warnings.warn(
-                "transit_time_method other than newton-raphson is not well tested.")
         self.transit_time_method = transit_time_method
         self.nitr_transit = nitr_transit
         self.nplanet = nplanet
@@ -176,8 +235,10 @@ class JaxTTV(Nbody):
         """compute model transit times 
 
             Note:
-                This function returns only transit times that are closest to the observed ones.
-                To get all the transit times, use get_transit_times_all instead.
+                This function returns only transit times that are closest to the
+                observed ones. The algorithm is controlled by
+                ``self.transit_time_method``. To get all the transit times, use
+                ``get_transit_times_all`` instead.
 
             Args:
                 par_dict: dict containing parameters
@@ -202,18 +263,17 @@ class JaxTTV(Nbody):
             orbit_idx = transit_orbit_idx[self.pidx.astype(
                 int) - 1].astype(int)
         tcobs1d = self.tcobs_flatten  # 1D array of observed transit times
-        if self.transit_time_method == 'newton-raphson':
-            transit_times = find_transit_times_all(
-                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_transit)
-        else:
-            transit_times = find_transit_times_kepler_all(
-                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_kepler)
+        transit_times = self._compute_transit_times(
+            orbit_idx, tcobs1d, times, xvjac, masses)
         ediff = get_energy_diff_jac(xvjac, masses, -0.5*self.dt)
         return transit_times, ediff
 
     @partial(jit, static_argnums=(0,))
     def get_transit_times_and_rvs_obs(self, par_dict, times_rv, transit_orbit_idx=None):
         """compute model transit times and stellar RVs
+
+            Note:
+                The transit times are computed using ``self.transit_time_method``.
 
             Args:
                 par_dict: dict containing parameters
@@ -240,12 +300,8 @@ class JaxTTV(Nbody):
             orbit_idx = transit_orbit_idx[self.pidx.astype(
                 int) - 1].astype(int)
         tcobs1d = self.tcobs_flatten  # 1D array of observed transit times
-        if self.transit_time_method == 'newton-raphson':
-            transit_times = find_transit_times_all(
-                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_transit)
-        else:
-            transit_times = find_transit_times_kepler_all(
-                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_kepler)
+        transit_times = self._compute_transit_times(
+            orbit_idx, tcobs1d, times, xvjac, masses)
         ediff = get_energy_diff_jac(xvjac, masses, -0.5*self.dt)
 
         nbodyrv = rv_from_xvjac(times_rv, times, xvjac, masses)
@@ -297,6 +353,10 @@ class JaxTTV(Nbody):
     def get_transit_times_all(self, par_dict, t_start=None, t_end=None, dt=None, transit_orbit_idx=None):
         """compute all model transit times between t_start and t_end
 
+            Note:
+                This function always uses the Newton transit finder, regardless
+                of ``self.transit_time_method``.
+
             Args:
                 par_dict: dict containing parameters
 
@@ -325,12 +385,8 @@ class JaxTTV(Nbody):
         else:
             orbit_idx = transit_orbit_idx[_orbit_idx.astype(
                 int) - 1].astype(int)
-        if self.transit_time_method == 'newton-raphson':
-            transit_times = find_transit_times_all(
-                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_transit)
-        else:
-            transit_times = find_transit_times_kepler_all(
-                orbit_idx, tcobs1d, times, xvjac, masses, nitr=self.nitr_kepler)
+        transit_times = self._compute_transit_times(
+            orbit_idx, tcobs1d, times, xvjac, masses, method="newton")
         ediff = get_energy_diff_jac(xvjac, masses, -0.5*dt)
 
         return transit_times, ediff, _orbit_idx.astype(int) - 1
@@ -431,16 +487,27 @@ class JaxTTV(Nbody):
         return {'mean': np.mean(res), 'sd': np.std(res)}, params_st
 
     def check_timing_precision(self, par_dict, dtfrac=1e-3, nitr_transit=10, nitr_kepler=10):
-        """compare get_ttvs output with that computed with a smaller timestep to check the precision
+        """Compare transit times against a smaller-step Newton calculation.
+
+            Note:
+                The baseline calculation uses the current
+                ``self.transit_time_method`` at the nominal timestep, while the
+                smaller-step reference always uses the Newton transit finder.
 
             Args:
                 params: JaxTTV parameter array
                 dtfrac: (innermost period) * dtfrac is used for the comparison integration
+                nitr_transit: number of Newton iterations for the smaller-step
+                    reference calculation
+                nitr_kepler: number of Kepler iterations for the smaller-step
+                    reference calculation
 
             Returns:
                 tuple:
-                    - model transit times from get_transit_times_obs
-                    - model transit times using a smaller timestep
+                    - model transit times from the baseline calculation at the
+                      nominal timestep
+                    - model transit times from the smaller-step Newton
+                      calculation
 
         """
         tc, de = self.get_transit_times_obs(par_dict)
@@ -454,6 +521,7 @@ class JaxTTV(Nbody):
         self2.times = jnp.arange(self2.t_start, self2.t_end, self2.dt)
         self2.nitr_kepler = nitr_kepler
         self2.nitr_transit = nitr_transit
+        self2.transit_time_method = "newton"
         tc2, de2 = self2.get_transit_times_obs(par_dict)
         intname = 'symplectic'
         print("# fractional energy error (%s, dt=%.2e): %.2e" %

--- a/src/jnkepler/jaxttv/jaxttv.py
+++ b/src/jnkepler/jaxttv/jaxttv.py
@@ -560,7 +560,7 @@ class JaxTTV(Nbody):
             if ylims is not None and len(ylims) == len(t0_lin):
                 ax2.set_ylim(ylims[j])
 
-            idxm = findidx_map(tcmodel, tcobs)
+            idxm = find_nearest_idx(tcmodel, tcobs)
             ax2.errorbar(tcobs, (tcobs-tcmodel[idxm])*unit, yerr=errorobs*unit, zorder=1000,
                          fmt='o', mfc='white', color='dimgray', label='data', lw=1, markersize=7)
             ax2.axhline(y=0, color='steelblue', alpha=0.6)

--- a/src/jnkepler/jaxttv/symplectic.py
+++ b/src/jnkepler/jaxttv/symplectic.py
@@ -2,7 +2,8 @@
 approach used in TTVFast (https://github.com/kdeck/TTVFast).
 """
 
-__all__ = ["integrate_xv", "kepler_step_map", "kick_kepler_map"]
+__all__ = ["integrate_xv", "kepler_step_map",
+           "kick_kepler_map", "kepler_kick_kepler_map"]
 
 import jax.numpy as jnp
 from functools import partial
@@ -12,6 +13,19 @@ from jax.lax import scan, while_loop
 from .conversion import G
 
 config.update("jax_enable_x64", True)
+
+
+def _compute_ki(masses):
+    """Return the effective two-body GM values for Jacobi coordinates.
+
+    Args:
+        masses: masses of the bodies (Nbody,), in units of solar mass
+
+    Returns:
+        GM values for each Jacobi orbit, shape (Norbit,)
+    """
+    csum = jnp.cumsum(masses)
+    return G * masses[0] * csum[1:] / jnp.hstack([masses[0], csum[1:][:-1]])
 
 
 def dEstep(x, ecosE0, esinE0, dM):
@@ -272,25 +286,25 @@ def nbody_kicks(x, v, ki, masses, dt):
 
 
 def integrate_xv(x, v, masses, times, nitr=10):
-    """symplectic integration of the orbits
+    """Integrate Jacobi positions and velocities using the Wisdom-Holman map.
+
+    This function currently assumes that `times` are uniformly spaced. Internally, the
+    map is initialized using the first time interval and then advanced with a
+    fixed step size, so non-uniform `times` are not supported.
 
     Args:
-        x: initial Jacobi positions (Norbit, xyz)
-        v: initial Jacobi velocities (Norbit, xyz)
+        x: initial Jacobi positions in Cartesian coordinates (Norbit, xyz)
+        v: initial Jacobi velocities in Cartesian coordinates (Norbit, xyz)
         masses: masses of the bodies (Nbody,), in units of solar mass
-        times: cumulative sum of time steps
+        times: 1D array of uniformly spaced output times
+        nitr: number of iterations in Kepler's equation solver
 
     Returns:
         tuple:
-            - times (initial time omitted; dt/2 ahead of the input)
-            - Jacobi position/velocity array (Nstep, x or v, Norbit, xyz)
+            - times at the middle of each map step
+            - integrated Jacobi positions and velocities
     """
-    ki = (
-        G
-        * masses[0]
-        * jnp.cumsum(masses)[1:]
-        / jnp.hstack([masses[0], jnp.cumsum(masses)[1:][:-1]])
-    )
+    ki = _compute_ki(masses)
     dtarr = jnp.diff(times)
 
     # transformation between the mapping and real Hamiltonian
@@ -322,12 +336,7 @@ def kepler_step_map(xjac, vjac, masses, dt, nitr=10):
     Returns:
         new Jacobi positions and velocities (Ntime, x or v, Norbit, xyz)
     """
-    ki = (
-        G
-        * masses[0]
-        * jnp.cumsum(masses)[1:]
-        / jnp.hstack([masses[0], jnp.cumsum(masses)[1:][:-1]])
-    )
+    ki = _compute_ki(masses)
 
     def step(x, v):
         return kepler_step(x, v, ki, dt, nitr=nitr)
@@ -348,18 +357,40 @@ def kick_kepler_map(xjac, vjac, masses, dt, nitr=10):
     Returns:
         new jacobi positions and velocities (Ntime, x or v, Norbit, xyz)
     """
-    ki = (
-        G
-        * masses[0]
-        * jnp.cumsum(masses)[1:]
-        / jnp.hstack([masses[0], jnp.cumsum(masses)[1:][:-1]])
-    )
+    ki = _compute_ki(masses)
 
     def kick_kepler(x, v):
         x, v = nbody_kicks(x, v, ki, masses, 2 * dt)
         return kepler_step(x, v, ki, dt, nitr=nitr)
 
     func_map = vmap(kick_kepler, (0, 0), 0)
+    return func_map(xjac, vjac)
+
+
+def kepler_kick_kepler_map(xjac, vjac, masses, dt, nitr=10):
+    """vmap version of kepler_step + nbody_kicks + kepler_step.
+
+    This applies a full KDK-like step written in the order
+    kepler(dt/2) -> kick(dt) -> kepler(dt/2) to each element along the
+    first axis.
+
+    Args:
+        xjac: Jacobi positions (Ntime, Norbit, xyz)
+        vjac: Jacobi velocities (Ntime, Norbit, xyz)
+        masses: masses of the bodies (Nbody,), in units of solar mass
+        dt: common full time step
+
+    Returns:
+        new Jacobi positions and velocities (Ntime, x or v, Norbit, xyz)
+    """
+    ki = _compute_ki(masses)
+
+    def kepler_kick_kepler(x, v):
+        x, v = kepler_step(x, v, ki, 0.5 * dt, nitr=nitr)
+        x, v = nbody_kicks(x, v, ki, masses, dt)
+        return kepler_step(x, v, ki, 0.5 * dt, nitr=nitr)
+
+    func_map = vmap(kepler_kick_kepler, (0, 0), 0)
     return func_map(xjac, vjac)
 
 

--- a/src/jnkepler/jaxttv/symplectic.py
+++ b/src/jnkepler/jaxttv/symplectic.py
@@ -385,13 +385,13 @@ def kepler_kick_kepler_map(xjac, vjac, masses, dt, nitr=10):
     """
     ki = _compute_ki(masses)
 
-    def kepler_kick_kepler(x, v):
+    def kepler_kick_kepler(x, v, dt):
         x, v = kepler_step(x, v, ki, 0.5 * dt, nitr=nitr)
         x, v = nbody_kicks(x, v, ki, masses, dt)
         return kepler_step(x, v, ki, 0.5 * dt, nitr=nitr)
 
-    func_map = vmap(kepler_kick_kepler, (0, 0), 0)
-    return func_map(xjac, vjac)
+    func_map = vmap(kepler_kick_kepler, (0, 0, 0), 0)
+    return func_map(xjac, vjac, dt)
 
 
 def compute_corrector_coefficientsTO():

--- a/src/jnkepler/jaxttv/utils.py
+++ b/src/jnkepler/jaxttv/utils.py
@@ -3,7 +3,7 @@ Internal utilities for parameter conversion, initialization, and diagnostics.
 """
 __all__ = [
     "initialize_jacobi_xv", "get_energy_diff", "get_energy_diff_jac",
-    "params_to_elements", "elements_to_pdic", "convert_elements", "findidx_map", "params_to_dict", "dict_to_params", "em_to_dict"
+    "params_to_elements", "elements_to_pdic", "convert_elements", "find_nearest_idx", "find_nearest_idx_sorted", "params_to_dict", "dict_to_params", "em_to_dict"
 ]
 
 import numpy as np
@@ -322,7 +322,7 @@ def convert_elements(par_dict, t_epoch, WHsplit=False):
     return xv_to_elements(xjac, vjac, ki), masses
 
 
-def findidx_map(arr1, arr2):
+def find_nearest_idx(arr1, arr2):
     """pick up elements of arr1 nearest to each element in arr2
 
         Args:
@@ -336,3 +336,33 @@ def findidx_map(arr1, arr2):
     def func(arr1, val): return jnp.argmin(jnp.abs(arr1 - val))
     func_map = jit(vmap(func, (None, 0), 0))
     return func_map(arr1, arr2)
+
+
+def find_nearest_idx_sorted(arr1, arr2):
+    """Return indices in sorted `arr1` nearest to each value in `arr2`.
+
+    This implementation assumes `arr1` is sorted in ascending order and uses
+    binary search via `jnp.searchsorted` (O(len(arr2) * log(len(arr1)))).
+
+    Ties are resolved by choosing the left candidate.
+
+    Args:
+        arr1: 1D array sorted in ascending order.
+        arr2: 1D array of query values.
+
+    Returns:
+        1D integer array of indices `i` such that `arr1[i]` is the nearest value
+        to each element of `arr2`.
+    """
+    N = arr1.shape[0]
+    # insertion positions in [0, N]
+    i = jnp.searchsorted(arr1, arr2, side="left")
+
+    # clamp to valid neighbor indices
+    i1 = jnp.clip(i, 0, N - 1)      # right candidate
+    i0 = jnp.clip(i - 1, 0, N - 1)  # left candidate
+
+    # pick the nearer one (tie -> left)
+    d0 = jnp.abs(arr2 - arr1[i0])
+    d1 = jnp.abs(arr1[i1] - arr2)
+    return jnp.where(d0 <= d1, i0, i1)

--- a/src/jnkepler/nbodytransit/nbodytransit.py
+++ b/src/jnkepler/nbodytransit/nbodytransit.py
@@ -9,7 +9,7 @@ from functools import partial
 from ..jaxttv import JaxTTV
 from ..jaxttv.utils import *
 from ..jaxttv.conversion import *
-from ..jaxttv.findtransit import *
+from ..jaxttv.findtransit import find_transit_params_all, find_transit_params_fast
 from ..jaxttv.symplectic import integrate_xv, kepler_step_map
 from ..jaxttv.hermite4 import integrate_xv as integrate_xv_hermite4
 from ..jaxttv.rv import *
@@ -93,8 +93,14 @@ class NbodyTransit(JaxTTV):
             xjac0, vjac0, masses, self.times, nitr=self.nitr_kepler)  # integration
         pidxarr = self.pidx.astype(int)  # idx for planet, starting from 1
         tcobs1d = self.tcobs_flatten
-        tc, (xcm, vcm, _) = find_transit_params_all(
-            pidxarr-1, tcobs1d, times, xvjac, masses)
+        if self.transit_time_method == "newton":
+            tc, (xcm, vcm, _) = find_transit_params_all(
+                pidxarr - 1, tcobs1d, times, xvjac, masses
+            )
+        else:
+            tc, (xcm, vcm, _) = find_transit_params_fast(
+                pidxarr - 1, tcobs1d, times, xvjac, masses
+            )
         xsky_tc, vsky_tc = get_xvast_map(xcm, vcm, pidxarr)
         return tc, xsky_tc, vsky_tc, times, xvjac, masses
 

--- a/src/jnkepler/nbodytransit/nbodytransit.py
+++ b/src/jnkepler/nbodytransit/nbodytransit.py
@@ -51,13 +51,13 @@ class NbodyTransit(JaxTTV):
         times_transit_idx, times_planet_idx = [], []
         for j in range(self.nplanet):
             tcj = np.where(self.pidx == j+1, self.tcobs_flatten, -np.inf)
-            _tidx = findidx_map(tcj, self.times_super)
+            _tidx = find_nearest_idx(tcj, self.times_super)
             _pidx = jnp.ones_like(_tidx) * j
             times_transit_idx.append(_tidx)
             times_planet_idx.append(_pidx)
         self.times_transit_idx = jnp.array(times_transit_idx)
         self.times_planet_idx = jnp.array(times_planet_idx)
-        self.times_transit_idx_nool = findidx_map(
+        self.times_transit_idx_nool = find_nearest_idx(
             self.tcobs_flatten, self.times_super)
         self.times_planet_idx_nool = self.pidx[self.times_transit_idx_nool].astype(
             int) - 1

--- a/tests/unittests/jaxttv/test_findtransit_fast.py
+++ b/tests/unittests/jaxttv/test_findtransit_fast.py
@@ -1,0 +1,67 @@
+import numpy as np
+import jax.numpy as jnp
+
+from jnkepler.tests import read_testdata_tc
+from jnkepler.jaxttv.findtransit import (
+    find_transit_times_all,
+    find_transit_times_fast,
+    find_transit_params_all,
+    find_transit_params_fast,
+)
+from jnkepler.jaxttv.jaxttv import initialize_jacobi_xv
+from jnkepler.jaxttv.symplectic import integrate_xv
+
+
+def _get_test_integration():
+    """Return a representative integrated system for transit-finder tests."""
+    jttv, _, _, pdic = read_testdata_tc()
+    xjac0, vjac0, masses = initialize_jacobi_xv(pdic, jttv.t_start)
+    times, xvjac = integrate_xv(
+        xjac0, vjac0, masses, jttv.times, nitr=jttv.nitr_kepler
+    )
+    pidxarr = jttv.pidx.astype(int) - 1
+    tcobsarr = jttv.tcobs_flatten
+    return jttv, pidxarr, tcobsarr, times, xvjac, masses
+
+
+def test_find_transit_times_fast_matches_newton():
+    jttv, pidxarr, tcobsarr, times, xvjac, masses = _get_test_integration()
+
+    tc_fast = find_transit_times_fast(pidxarr, tcobsarr, times, xvjac, masses)
+    tc_newton = find_transit_times_all(
+        pidxarr, tcobsarr, times, xvjac, masses, nitr=jttv.nitr_transit
+    )
+
+    assert tc_fast.shape == tc_newton.shape
+    assert np.all(np.isfinite(np.asarray(tc_fast)))
+    assert np.allclose(tc_fast, tc_newton, rtol=0.0, atol=1e-6)
+
+
+def test_find_transit_params_fast_matches_newton():
+    jttv, pidxarr, tcobsarr, times, xvjac, masses = _get_test_integration()
+
+    tc_fast, (xcm_fast, vcm_fast, dt_fast) = find_transit_params_fast(
+        pidxarr, tcobsarr, times, xvjac, masses
+    )
+    tc_newton, (xcm_newton, vcm_newton, dt_newton) = find_transit_params_all(
+        pidxarr, tcobsarr, times, xvjac, masses, nitr=jttv.nitr_transit
+    )
+
+    assert tc_fast.shape == tc_newton.shape
+    assert xcm_fast.shape == xcm_newton.shape
+    assert vcm_fast.shape == vcm_newton.shape
+    assert dt_fast.shape == dt_newton.shape
+
+    assert np.all(np.isfinite(np.asarray(tc_fast)))
+    assert np.all(np.isfinite(np.asarray(xcm_fast)))
+    assert np.all(np.isfinite(np.asarray(vcm_fast)))
+    assert np.all(np.isfinite(np.asarray(dt_fast)))
+
+    assert np.allclose(tc_fast, tc_newton, rtol=0.0, atol=1e-6)
+    assert np.allclose(xcm_fast, xcm_newton, rtol=0.0, atol=1e-6)
+    assert np.allclose(vcm_fast, vcm_newton, rtol=0.0, atol=1e-6)
+
+    # Returned corrections should be small and the selected planets should be
+    # close to the transit center (x · v ≈ 0 in the sky plane).
+    dt_step = float(np.diff(np.asarray(times))[0])
+    assert np.all(np.abs(np.asarray(dt_fast)) < 0.1 * dt_step)

--- a/tests/unittests/jaxttv/test_jaxttv.py
+++ b/tests/unittests/jaxttv/test_jaxttv.py
@@ -5,7 +5,7 @@ from importlib.util import find_spec
 import pickle
 from jnkepler.tests import read_testdata_tc, read_testdata_4planet
 from jnkepler.jaxttv.ttvfastutils import params_for_ttvfast, get_ttvfast_model_rv, get_ttvfast_model
-from jnkepler.jaxttv.utils import em_to_dict, params_to_elements, elements_to_pdic, findidx_map
+from jnkepler.jaxttv.utils import em_to_dict, params_to_elements, elements_to_pdic, find_nearest_idx
 
 path = importlib_resources.files('jnkepler').joinpath('data')
 
@@ -134,7 +134,7 @@ def get_ttvfast_times(jttv, pdic, nplanet, obs=True, **kwargs):
     if not obs:
         return tcs_ttvfast
 
-    idx_for_tf = findidx_map(tcs_ttvfast, jttv.tcobs_flatten)
+    idx_for_tf = find_nearest_idx(tcs_ttvfast, jttv.tcobs_flatten)
     tc_tf = tcs_ttvfast[idx_for_tf]
 
     return tc_tf
@@ -152,7 +152,7 @@ def get_ttvfast_times_and_rvs(jttv, pdic, nplanet, times_rv, obs=True, **kwargs)
     tcs_ttvfast = np.hstack(tcs_ttvfast)
 
     if obs:
-        idx_for_tf = findidx_map(tcs_ttvfast, jttv.tcobs_flatten)
+        idx_for_tf = find_nearest_idx(tcs_ttvfast, jttv.tcobs_flatten)
         tcs_ttvfast = tcs_ttvfast[idx_for_tf]
 
     return tcs_ttvfast, rvs

--- a/tests/unittests/nbodytransit/test_nbodytransit.py
+++ b/tests/unittests/nbodytransit/test_nbodytransit.py
@@ -84,10 +84,10 @@ def test_get_flux():
     nt.set_lcobs(times_lc)
     lc, ttv = nt.get_flux(par_dict)
 
-    lc_test = np.loadtxt(path/"kep51_lc_model.txt")
+    lc_test = np.loadtxt(path/"kep51_lc_model.txt") - 1.
 
-    assert lc == pytest.approx(lc_test-1.)
-    print("# max fractional difference:", np.max(np.abs(lc-lc_test)))
+    assert lc == pytest.approx(lc_test, abs=1e-8)
+    print("# max absolute difference:", np.max(np.abs(lc-lc_test)))
 
 
 @pytest.mark.skipif(not JAXOPLANET_INSTALLED, reason="jaxoplanet is not installed")
@@ -113,7 +113,6 @@ def test_get_flux_and_rv():
 
 
 if __name__ == '__main__':
-    # compute_testlc()
     test_get_xvsky_tc()
     test_get_flux()
     test_get_flux_and_rv()

--- a/tests/unittests/test_information.py
+++ b/tests/unittests/test_information.py
@@ -54,24 +54,24 @@ def test_information_from_model_independent_normal():
     info_c = information_from_model_independent_normal(model=model_normal, mu_name="tcmodel", pdic=pdic, keys=sample_keys, sigma_sd=jttv.errorobs_flatten,
                                                        observed=jttv.tcobs_flatten, param_space="constrained", model_args=(sample_keys, param_bounds))['fisher']
     info_c_ref = np.loadtxt(path/"info.txt")
-    assert np.allclose(info_c, info_c_ref)
+    assert np.allclose(info_c, info_c_ref, rtol=1e-4)
 
     info_u = information_from_model_independent_normal(model=model_normal, mu_name="tcmodel", pdic=pdic, keys=sample_keys, sigma_sd=jttv.errorobs_flatten,
                                                        observed=jttv.tcobs_flatten, param_space="unconstrained", model_args=(sample_keys, param_bounds))['fisher']
     info_u_ref = np.load(path/"info_unconstrained_ref.npy")
-    assert np.allclose(info_u, info_u_ref)
+    assert np.allclose(info_u, info_u_ref, rtol=1e-4)
 
     sample_keys_lnpmass = ["ecosw", "esinw", "lnpmass", "period", "tic"]
     pdic['lnpmass'] = np.log(pdic['pmass'])
     info_c_lnpmass = information_from_model_independent_normal(model=model_normal, mu_name="tcmodel", pdic=pdic, keys=sample_keys_lnpmass,
                                                                sigma_sd=jttv.errorobs_flatten, observed=jttv.tcobs_flatten, param_space="constrained", model_args=(sample_keys_lnpmass, param_bounds))['fisher']
     info_c_ref_lnpmass = np.load(path/"info_lnpmass.npy")
-    assert np.allclose(info_c_lnpmass, info_c_ref_lnpmass)
+    assert np.allclose(info_c_lnpmass, info_c_ref_lnpmass, rtol=1e-4)
 
     info_u_lnpmass = information_from_model_independent_normal(model=model_normal, mu_name="tcmodel", pdic=pdic, keys=sample_keys_lnpmass,
                                                                sigma_sd=jttv.errorobs_flatten, observed=jttv.tcobs_flatten, param_space="unconstrained", model_args=(sample_keys_lnpmass, param_bounds))['fisher']
     info_u_ref_lnpmass = np.load(path/"info_unconstrained_ref_lnpmass.npy")
-    assert np.allclose(info_u_lnpmass, info_u_ref_lnpmass)
+    assert np.allclose(info_u_lnpmass, info_u_ref_lnpmass, rtol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR refactors the transit-time calculation interface, implements a fast transit-finding method, and makes it the default option.

### Main changes

- implement a fast transit-finding method based on advancing states to the observed transit times and evaluating the timing correction there
- make `fast` the default `transit_time_method`
- keep `newton` and `kepler` as selectable options for compatibility
- keep `find_transit_times_kepler_all` for backward compatibility
- update `NbodyTransit` so that transit-center evaluation respects `transit_time_method`
- clean up helper naming / visibility and docstrings in `findtransit.py`

### jacfwd fix

This PR also fixes NaNs in `jacfwd` by avoiding `sqrt(0)` in `get_acm`, so the transit-time path is now compatible with both `jacrev` and `jacfwd`.

## Notes

- `kepler` is kept for compatibility and is not intended to be the default method going forward.
- `find_transit_times_kepler_all` is retained for now and can be deprecated later.