### PR TITLE
Cherry-pick core fixes from PR #40

### DIFF
--- a/src/jnkepler/jaxttv/findtransit.py
+++ b/src/jnkepler/jaxttv/findtransit.py
@@ -145,17 +145,26 @@ def _find_transit_newton_core(pidxarr, tcobsarr, t, xvjac, masses, nitr):
 
 
 def _find_tc_idx_sorted(t, tcobs):
-    """Find indices in ``t[1:]`` nearest to the target transit times.
+    """Find indices in ``t[1:]`` whose step-boundary times are nearest to
+    the target transit times.
+
+    The times returned by ``integrate_xv`` are at the midpoints of each
+    mapping step.  The fast transit finder corrects back by ``dt/2`` to
+    obtain step-boundary times before advancing to the observed transits.
+    This function searches on the corrected (boundary) times so that the
+    nearest step minimises the subsequent advance.
 
     Args:
-        t: Time array of shape ``(Nstep,)``.
+        t: Time array of shape ``(Nstep,)``.  Must be uniformly spaced
+            (as guaranteed by ``integrate_xv``).
         tcobs: Target transit time or times. A scalar or array-like input is
             accepted.
 
     Returns:
-        Indices in ``t[1:]`` nearest to ``tcobs``.
+        Indices in ``t[1:]`` nearest to ``tcobs`` in step-boundary time.
     """
-    return find_nearest_idx_sorted(t[1:], jnp.atleast_1d(tcobs))
+    dt = jnp.diff(t)[0]  # uniform spacing assumed
+    return find_nearest_idx_sorted(t[1:] - 0.5 * dt, jnp.atleast_1d(tcobs))
 
 
 def _advance_to_tcobs_fast(tcidx, pidxarr, tcobsarr, t, xvjac, masses):

--- a/src/jnkepler/jaxttv/hermite4.py
+++ b/src/jnkepler/jaxttv/hermite4.py
@@ -32,11 +32,12 @@ def get_derivs(x, v, masses):
     x2jk = jnp.sum(xjk * xjk, axis=1)[:, None, :]
     xvjk = jnp.sum(xjk * vjk, axis=1)[:, None, :]
 
-    x2jk = jnp.where(x2jk != 0., x2jk, jnp.inf)
-    x2jkinv = 1. / x2jk
+    nz = x2jk != 0.
+    x2jk_safe = jnp.where(nz, x2jk, 1.0)
+    x2jkinv = 1. / x2jk_safe
     x2jkinv1p5 = x2jkinv * jnp.sqrt(x2jkinv)
-    Xjk = - xjk * x2jkinv1p5
-    dXjk = (- vjk + 3 * xvjk * xjk * x2jkinv) * x2jkinv1p5
+    Xjk = jnp.where(nz, - xjk * x2jkinv1p5, 0.0)
+    dXjk = jnp.where(nz, (- vjk + 3 * xvjk * xjk * x2jkinv) * x2jkinv1p5, 0.0)
 
     a = G * jnp.dot(Xjk, masses)
     adot = G * jnp.dot(dXjk, masses)

--- a/src/jnkepler/jaxttv/utils.py
+++ b/src/jnkepler/jaxttv/utils.py
@@ -183,8 +183,12 @@ def get_energy(x, v, masses):
     """
     K = jnp.sum(0.5 * masses * jnp.sum(v*v, axis=1))
     X = x[:, None] - x[None, :]
+    d2 = jnp.sum(X*X, axis=2)
+    mask = jnp.tril(jnp.ones_like(d2, dtype=bool), k=-1)
+    d2_safe = jnp.where(mask, d2, 1.0)
+    inv_r = jnp.where(mask, 1.0 / jnp.sqrt(d2_safe), 0.0)
     M = masses[:, None] * masses[None, :]
-    U = -G * jnp.sum(M * jnp.tril(1./jnp.sqrt(jnp.sum(X*X, axis=2)), k=-1))
+    U = -G * jnp.sum(M * inv_r)
     return K + U
 
 


### PR DESCRIPTION
This cherry-picks the two core fixes from PR #40:

- safe masking fix to avoid NaNs in jacfwd for hermite4.get_derivs and get_energy
- fast transit finder indexing fix in _find_tc_idx_sorted

Intentionally excluded:
- check_timestep / check_timing_precision changes
- changes to least-squares diff_mode defaults
- notebook or documentation changes
