### PR TITLE
Fix/rv times range

### DIFF
--- a/src/jnkepler/jaxttv/jaxttv.py
+++ b/src/jnkepler/jaxttv/jaxttv.py
@@ -42,6 +42,31 @@ class Nbody:
         self.times = jnp.arange(t_start, t_end, dt)
         self.nitr_kepler = nitr_kepler
 
+    def _rv_interpolation_time_range(self):
+        """Return the time range used for RV interpolation."""
+        times = np.asarray(self.times)
+        if times.size == 0:
+            return float(self.t_start), float(self.t_end)
+        if times.size < 2:
+            return float(times[0]), float(times[-1])
+
+        dt = times[1] - times[0]
+        return float(times[1] + 0.5 * dt), float(times[-1] + 0.5 * dt)
+
+    def _validate_times_rv(self, times_rv):
+        times_rv = np.asarray(times_rv)
+        finite_mask = np.isfinite(times_rv)
+        if not np.any(finite_mask):
+            return
+
+        t_min, t_max = self._rv_interpolation_time_range()
+        finite_times = times_rv[finite_mask]
+        if np.any((finite_times < t_min) | (finite_times > t_max)):
+            raise ValueError(
+                "times_rv contains finite values outside the valid integration "
+                f"range [{t_min}, {t_max}]."
+            )
+
 
 class JaxTTV(Nbody):
     """main class for TTV analysis"""
@@ -268,7 +293,6 @@ class JaxTTV(Nbody):
         ediff = get_energy_diff_jac(xvjac, masses, -0.5*self.dt)
         return transit_times, ediff
 
-    @partial(jit, static_argnums=(0,))
     def get_transit_times_and_rvs_obs(self, par_dict, times_rv, transit_orbit_idx=None):
         """compute model transit times and stellar RVs
 
@@ -289,6 +313,12 @@ class JaxTTV(Nbody):
                     - float: fractional energy change
 
         """
+        self._validate_times_rv(times_rv)
+        return self._get_transit_times_and_rvs_obs(
+            par_dict, times_rv, transit_orbit_idx=transit_orbit_idx)
+
+    @partial(jit, static_argnums=(0,))
+    def _get_transit_times_and_rvs_obs(self, par_dict, times_rv, transit_orbit_idx=None):
         xjac0, vjac0, masses = initialize_jacobi_xv(
             par_dict, self.t_start)  # initial Jacobi position/velocity
         times, xvjac = integrate_xv(

--- a/src/jnkepler/jaxttv/rv.py
+++ b/src/jnkepler/jaxttv/rv.py
@@ -24,4 +24,6 @@ def rv_from_xvjac(times_rv, times, xvjac, masses):
     xast, vast = jacobi_to_astrocentric(
         xvjac[:, 0, :, :], xvjac[:, 1, :, :], masses)
     xcm, vcm = a2cm_map(xast, vast, masses)
-    return - jnp.interp(times_rv, times, vcm[:, 0, 2]) * au_per_day
+    return - jnp.interp(
+        times_rv, times, vcm[:, 0, 2], left=jnp.nan, right=jnp.nan
+    ) * au_per_day

--- a/src/jnkepler/nbodyrv/nbodyrv.py
+++ b/src/jnkepler/nbodyrv/nbodyrv.py
@@ -34,6 +34,7 @@ class NbodyRV(Nbody):
                 array: stellar RVs at times_rvs (m/s), positive when the star is moving away
 
         """
+        self._validate_times_rv(times_rv)
         xjac0, vjac0, masses = initialize_jacobi_xv(
             par_dict, self.t_start)
         times, xvjac = integrate_xv(

--- a/src/jnkepler/nbodytransit/nbodytransit.py
+++ b/src/jnkepler/nbodytransit/nbodytransit.py
@@ -136,7 +136,6 @@ class NbodyTransit(JaxTTV):
 
         return nbodyflux, tc
 
-    @partial(jit, static_argnums=(0,))
     def get_flux_and_rv(self, par_dict, times_rv):
         """compute nbody flux and RV
 
@@ -155,6 +154,11 @@ class NbodyTransit(JaxTTV):
                     - stellar RVs at times_rvs (m/s), positive when the star is moving away
 
         """
+        self._validate_times_rv(times_rv)
+        return self._get_flux_and_rv(par_dict, times_rv)
+
+    @partial(jit, static_argnums=(0,))
+    def _get_flux_and_rv(self, par_dict, times_rv):
         _par_dict = initialize_transit_params(par_dict)
         tc, xsky_tc, vsky_tc, times, xvjac, masses = self.get_xvsky_tc(
             _par_dict)

--- a/tests/unittests/jaxttv/test_jaxttv.py
+++ b/tests/unittests/jaxttv/test_jaxttv.py
@@ -1,10 +1,12 @@
 import numpy as np
 import jax.numpy as jnp
 import importlib_resources
+import pytest
 from importlib.util import find_spec
 import pickle
 from jnkepler.tests import read_testdata_tc, read_testdata_4planet
 from jnkepler.jaxttv.ttvfastutils import params_for_ttvfast, get_ttvfast_model_rv, get_ttvfast_model
+from jnkepler.jaxttv.rv import rv_from_xvjac
 from jnkepler.jaxttv.utils import em_to_dict, params_to_elements, elements_to_pdic, find_nearest_idx
 
 path = importlib_resources.files('jnkepler').joinpath('data')
@@ -118,6 +120,28 @@ def test_get_transit_times_and_rvs_obs():
 
     assert np.allclose(tc_jttv, tc_ttvfast, rtol=0, atol=1e-5)
     assert np.allclose(rv_jttv, rv_ttvfast, rtol=0, atol=5e-3)
+
+
+@pytest.mark.parametrize("side", ["below", "above"])
+def test_get_transit_times_and_rvs_obs_times_rv_outside_range_raises(side):
+    jttv, _, _, pdic = read_testdata_tc()
+    t_min, t_max = jttv._rv_interpolation_time_range()
+    time_rv = t_min - 1e-8 if side == "below" else t_max + 1e-8
+
+    with pytest.raises(ValueError, match="times_rv.*valid integration range"):
+        jttv.get_transit_times_and_rvs_obs(pdic, np.array([time_rv]))
+
+
+def test_rv_from_xvjac_out_of_range_times_return_nan():
+    times = jnp.array([0.0, 1.0, 2.0])
+    xvjac = jnp.zeros((3, 2, 1, 3))
+    xvjac = xvjac.at[:, 1, 0, 2].set(jnp.array([1.0, 2.0, 3.0]))
+    masses = jnp.array([1.0, 1e-3])
+
+    rv = rv_from_xvjac(jnp.array([-1.0, 0.5, 3.0]), times, xvjac, masses)
+
+    assert np.isnan(np.asarray(rv)[[0, 2]]).all()
+    assert np.isfinite(np.asarray(rv)[1])
 
 
 def get_ttvfast_times(jttv, pdic, nplanet, obs=True, **kwargs):


### PR DESCRIPTION
Fixes #39.

This prevents out-of-range RV times from silently returning edge RV values from `jnp.interp`.

Changes:
- Add a Python-level `ValueError` check for out-of-range `times_rv` before calling the jitted RV calculation.
- Set `left=jnp.nan` and `right=jnp.nan` in the lower-level RV interpolation as a defensive fallback.
- Add tests for out-of-range, endpoint, and in-range RV times.

This keeps the existing public interface unchanged. A broader cleanup of how observation times are stored and validated can be considered separately.
