### PR TITLE
Default TTV least-squares optimizer to Newton and jacfwd

### DIFF
--- a/src/jnkepler/jaxttv/infer.py
+++ b/src/jnkepler/jaxttv/infer.py
@@ -18,7 +18,70 @@ from copy import deepcopy
 import time
 import warnings
 
-from .utils import params_to_dict, dict_to_params
+from .symplectic import integrate_xv
+from .utils import (
+    dict_to_params,
+    get_energy_diff_jac,
+    initialize_jacobi_xv,
+    params_to_dict,
+)
+
+
+def _canonicalize_transit_time_method(method):
+    """Return the canonical transit-time method name."""
+    if method is None:
+        return None
+    if method == "newton-raphson":
+        warnings.warn(
+            "'newton-raphson' is deprecated; use 'newton' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        method = "newton"
+    elif method == "interpolation":
+        warnings.warn(
+            "'interpolation' is deprecated; use 'kepler' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        method = "kepler"
+
+    if method not in ("fast", "newton", "kepler"):
+        raise ValueError(
+            "transit_time_method must be one of 'fast', 'newton', or 'kepler'."
+        )
+    return method
+
+
+def _get_transit_times_obs_with_method(
+    jttv,
+    par_dict,
+    transit_orbit_idx=None,
+    transit_time_method=None,
+):
+    """Compute observed transit times with an explicit transit-time method."""
+    if transit_time_method is None:
+        transit_time_method = jttv.transit_time_method
+
+    xjac0, vjac0, masses = initialize_jacobi_xv(par_dict, jttv.t_start)
+    times, xvjac = integrate_xv(
+        xjac0, vjac0, masses, jttv.times, nitr=jttv.nitr_kepler)
+
+    if transit_orbit_idx is None:
+        orbit_idx = jttv.pidx.astype(int) - 1
+    else:
+        orbit_idx = transit_orbit_idx[jttv.pidx.astype(int) - 1].astype(int)
+
+    transit_times = jttv._compute_transit_times(
+        orbit_idx,
+        jttv.tcobs_flatten,
+        times,
+        xvjac,
+        masses,
+        method=transit_time_method,
+    )
+    ediff = get_energy_diff_jac(xvjac, masses, -0.5 * jttv.dt)
+    return transit_times, ediff
 
 
 def ttv_default_parameter_bounds(jttv, npl=None, t0_guess=None, p_guess=None,
@@ -117,6 +180,7 @@ def _get_cached_residual_functions(
     npl,
     keys,
     transit_orbit_idx=None,
+    transit_time_method=None,
     jac=False,
     diff_mode="fwd",
 ):
@@ -133,6 +197,7 @@ def _get_cached_residual_functions(
         npl,
         tuple(keys),
         None if transit_orbit_idx is None else tuple(transit_orbit_idx),
+        transit_time_method,
         bool(jac),
         diff_mode,
     )
@@ -140,9 +205,11 @@ def _get_cached_residual_functions(
     if cache_key not in jttv._lsq_cache:
         def _model(p_flat):
             pdic = params_to_dict(p_flat, npl, keys)
-            return jttv.get_transit_times_obs(
+            return _get_transit_times_obs_with_method(
+                jttv,
                 pdic,
                 transit_orbit_idx=transit_orbit_idx,
+                transit_time_method=transit_time_method,
             )[0]
 
         def _resid(p_flat):
@@ -266,7 +333,7 @@ def ttv_optim_least_squares(
     loss="linear",
     loss_kwargs=None,
     jac=False,
-    diff_mode="auto",
+    diff_mode="fwd",
     plot=True,
     save=None,
     transit_orbit_idx=None,
@@ -275,6 +342,7 @@ def ttv_optim_least_squares(
     param_transform=None,
     return_optspace=False,
     gaussian_priors=None,
+    transit_time_method="newton",
 ):
     """Simple TTV fit using scipy.optimize.least_squares.
 
@@ -312,13 +380,11 @@ def ttv_optim_least_squares(
         jac: if True, use a JAX-based analytic Jacobian for the residual
             function.
         diff_mode: differentiation mode for the analytic Jacobian when
-            jac=True. Must be one of:
+            jac=True. Defaults to 'fwd' (``jax.jacfwd``). Must be one of:
+              - 'fwd': use ``jax.jacfwd``
+              - 'rev': use ``jax.jacrev``
               - 'auto': use 'fwd' for transit_time_method='fast' and
                 'rev' for transit_time_method='newton'
-              - 'rev'
-              - 'fwd'
-            Note: for transit_time_method='newton', 'fwd' is overridden to
-            'rev' because forward-mode differentiation may fail there.
         plot: if True, TTV models are plotted with data.
         save: path to save TTV plots.
         transit_orbit_idx: list of indices to specify which planets are
@@ -361,6 +427,10 @@ def ttv_optim_least_squares(
                     'period': {'index': 7, 'mean': 60.0, 'sigma': 1.0},
                     'lnpmass': {'index': 7, 'mean': np.log(3e-5), 'sigma': 0.5},
                 }
+        transit_time_method: algorithm used for transit-time computation during
+            least-squares optimization. Defaults to 'newton'. Supported values
+            are 'fast', 'newton', and 'kepler'. Set to None to use
+            ``jttv.transit_time_method``.
 
     Returns:
         dict or tuple:
@@ -384,8 +454,10 @@ def ttv_optim_least_squares(
             f"diff_mode must be 'auto', 'rev', or 'fwd', got {diff_mode!r}"
         )
 
-    # resolve differentiation mode
-    transit_time_method = jttv.transit_time_method
+    # resolve transit-time and differentiation modes
+    transit_time_method = _canonicalize_transit_time_method(transit_time_method)
+    if transit_time_method is None:
+        transit_time_method = jttv.transit_time_method
 
     if diff_mode == "auto":
         effective_diff_mode = (
@@ -393,13 +465,6 @@ def ttv_optim_least_squares(
         )
     else:
         effective_diff_mode = diff_mode
-
-    if jac and transit_time_method == "newton" and effective_diff_mode == "fwd":
-        warnings.warn(
-            "diff_mode='fwd' is not supported reliably with "
-            "transit_time_method='newton'; using diff_mode='rev' instead."
-        )
-        effective_diff_mode = "rev"
 
     # check non-transiting planets
     npl = len(param_bounds["period"][0])
@@ -544,6 +609,7 @@ def ttv_optim_least_squares(
         npl=npl,
         keys=keys,
         transit_orbit_idx=transit_orbit_idx,
+        transit_time_method=transit_time_method,
         jac=jac,
         diff_mode=effective_diff_mode,
     )
@@ -751,20 +817,21 @@ def ttv_optim_least_squares(
             np.median(np.asarray(jttv.errorobs_flatten, dtype=float)))
 
         tc_fast = np.asarray(
-            jttv.get_transit_times_obs(
+            _get_transit_times_obs_with_method(
+                jttv,
                 pdic_opt,
                 transit_orbit_idx=transit_orbit_idx,
+                transit_time_method="fast",
             )[0],
             dtype=float,
         )
 
-        jttv_newton = deepcopy(jttv)
-        jttv_newton.transit_time_method = "newton"
-
         tc_newton = np.asarray(
-            jttv_newton.get_transit_times_obs(
+            _get_transit_times_obs_with_method(
+                jttv,
                 pdic_opt,
                 transit_orbit_idx=transit_orbit_idx,
+                transit_time_method="newton",
             )[0],
             dtype=float,
         )

--- a/tests/unittests/jaxttv/test_infer.py
+++ b/tests/unittests/jaxttv/test_infer.py
@@ -1,0 +1,194 @@
+import inspect
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+
+
+def _load_infer_module():
+    src_root = Path(__file__).resolve().parents[3] / "src" / "jnkepler"
+    package_name = "_jnkepler_testpkg"
+    jaxttv_name = f"{package_name}.jaxttv"
+    infer_name = f"{jaxttv_name}.infer"
+
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(src_root)]
+    sys.modules.setdefault(package_name, package)
+
+    jaxttv_package = types.ModuleType(jaxttv_name)
+    jaxttv_package.__path__ = [str(src_root / "jaxttv")]
+    sys.modules.setdefault(jaxttv_name, jaxttv_package)
+
+    spec = importlib.util.spec_from_file_location(
+        infer_name,
+        src_root / "jaxttv" / "infer.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[infer_name] = module
+
+    missing = object()
+    old_scipy_modules = {
+        name: sys.modules.get(name, missing)
+        for name in ("scipy", "scipy.special", "scipy.optimize")
+    }
+
+    scipy_module = types.ModuleType("scipy")
+    scipy_special = types.ModuleType("scipy.special")
+    scipy_optimize = types.ModuleType("scipy.optimize")
+    scipy_special.gammaln = math.lgamma
+
+    def _least_squares_placeholder(*args, **kwargs):
+        raise AssertionError("least_squares should be monkeypatched in this test")
+
+    scipy_optimize.least_squares = _least_squares_placeholder
+    scipy_module.special = scipy_special
+    scipy_module.optimize = scipy_optimize
+
+    sys.modules["scipy"] = scipy_module
+    sys.modules["scipy.special"] = scipy_special
+    sys.modules["scipy.optimize"] = scipy_optimize
+
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, old_module in old_scipy_modules.items():
+            if old_module is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+
+    return module
+
+
+infer = _load_infer_module()
+
+
+def _param_bounds():
+    return {
+        "period": [np.array([1.0]), np.array([2.0])],
+        "ecosw": [np.array([-0.1]), np.array([0.1])],
+        "esinw": [np.array([-0.1]), np.array([0.1])],
+        "cosi": [np.array([-0.1]), np.array([0.1])],
+        "lnode": [np.array([-0.1]), np.array([0.1])],
+        "tic": [np.array([0.0]), np.array([1.0])],
+        "lnpmass": [np.array([-20.0]), np.array([-10.0])],
+    }
+
+
+def _fake_jttv():
+    return SimpleNamespace(
+        transit_time_method="fast",
+        nplanet=1,
+        tcobs_flatten=np.array([0.0]),
+        errorobs_flatten=np.array([1.0]),
+        tcobs=[np.array([0.0])],
+    )
+
+
+def _run_stubbed_lsq(monkeypatch, **kwargs):
+    captured = {}
+
+    def fake_get_cached_residual_functions(
+        jttv,
+        npl,
+        keys,
+        transit_orbit_idx=None,
+        transit_time_method=None,
+        jac=False,
+        diff_mode="fwd",
+    ):
+        captured["transit_time_method"] = transit_time_method
+        captured["diff_mode"] = diff_mode
+
+        def resid(p):
+            return jnp.array([p[0] - 1.5])
+
+        def jac_resid(p):
+            return jnp.zeros((1, p.shape[0])).at[0, 0].set(1.0)
+
+        return {
+            "resid": resid,
+            "jac_resid": jac_resid if jac else None,
+            "is_warmed": False,
+        }
+
+    def fake_least_squares(
+        fun,
+        p0,
+        jac,
+        bounds,
+        method,
+        loss,
+        f_scale,
+        max_nfev,
+    ):
+        captured["least_squares_jac"] = jac
+        return SimpleNamespace(x=np.asarray(p0), cost=0.0, nfev=1)
+
+    def fake_get_transit_times_obs_with_method(*args, **kwargs):
+        return jnp.array([0.0]), jnp.array(0.0)
+
+    monkeypatch.setattr(
+        infer,
+        "_get_cached_residual_functions",
+        fake_get_cached_residual_functions,
+    )
+    monkeypatch.setattr(
+        infer,
+        "_get_transit_times_obs_with_method",
+        fake_get_transit_times_obs_with_method,
+    )
+    monkeypatch.setattr(infer, "least_squares", fake_least_squares)
+
+    jttv = _fake_jttv()
+    infer.ttv_optim_least_squares(
+        jttv,
+        _param_bounds(),
+        jac=True,
+        plot=False,
+        **kwargs,
+    )
+    captured["jttv_transit_time_method"] = jttv.transit_time_method
+    return captured
+
+
+def test_ttv_optim_least_squares_defaults_to_newton_and_jacfwd():
+    sig = inspect.signature(infer.ttv_optim_least_squares)
+
+    assert sig.parameters["transit_time_method"].default == "newton"
+    assert sig.parameters["diff_mode"].default == "fwd"
+
+
+def test_ttv_optim_least_squares_default_modes(monkeypatch):
+    captured = _run_stubbed_lsq(monkeypatch)
+
+    assert captured["transit_time_method"] == "newton"
+    assert captured["diff_mode"] == "fwd"
+    assert captured["jttv_transit_time_method"] == "fast"
+
+
+def test_ttv_optim_least_squares_explicit_modes_are_preserved(monkeypatch):
+    captured = _run_stubbed_lsq(
+        monkeypatch,
+        transit_time_method="fast",
+        diff_mode="rev",
+    )
+
+    assert captured["transit_time_method"] == "fast"
+    assert captured["diff_mode"] == "rev"
+
+
+def test_ttv_optim_least_squares_explicit_auto_mode_is_preserved(monkeypatch):
+    captured = _run_stubbed_lsq(
+        monkeypatch,
+        transit_time_method="newton",
+        diff_mode="auto",
+    )
+
+    assert captured["transit_time_method"] == "newton"
+    assert captured["diff_mode"] == "rev"


### PR DESCRIPTION
## Summary

- Change `ttv_optim_least_squares` to use `transit_time_method="newton"` by default.
- Change the default analytic Jacobian mode from `diff_mode="auto"` to `diff_mode="fwd"` so `jac=True` uses `jax.jacfwd` by default.
- Preserve explicit user choices for `transit_time_method` and `diff_mode`.
- Avoid mutating `jttv.transit_time_method` during least-squares optimization by passing the optimizer method explicitly through the residual path.
- Add focused tests for the new defaults and explicit override behavior.

## Behavior Changes

The least-squares optimizer now defaults to the more robust Newton transit-time solver. Users who already have a good initial solution and want faster evaluations can still opt into `transit_time_method="fast"` explicitly.

Calling:

```python
ttv_optim_least_squares(jttv, bounds)
```

now evaluates transit times using the Newton solver by default, regardless of `jttv.transit_time_method`.

Users can still request the old fast behavior explicitly:

```python
ttv_optim_least_squares(jttv, bounds, transit_time_method="fast")
```

or defer to the `JaxTTV` object setting:

```python
ttv_optim_least_squares(jttv, bounds, transit_time_method=None)
```
