### PR TITLE
skip times_rv range check when input is a jax tracer

### DIFF
--- a/src/jnkepler/jaxttv/jaxttv.py
+++ b/src/jnkepler/jaxttv/jaxttv.py
@@ -19,6 +19,7 @@ from .symplectic import integrate_xv, kepler_step_map
 from .hermite4 import integrate_xv as integrate_xv_hermite4
 from .rv import *
 from ..infer import fit_t_distribution
+import jax
 from jax import jit, grad, config
 config.update('jax_enable_x64', True)
 
@@ -54,7 +55,13 @@ class Nbody:
         return float(times[1] + 0.5 * dt), float(times[-1] + 0.5 * dt)
 
     def _validate_times_rv(self, times_rv):
-        times_rv = np.asarray(times_rv)
+        try:
+            times_rv = np.asarray(times_rv)
+        except jax.errors.TracerArrayConversionError:
+            # times_rv is a JAX tracer, so its values are not known yet. This is
+            # a concrete-input guard only; skip it rather than fail when the
+            # caller is inside a traced function (e.g. a numpyro model).
+            return
         finite_mask = np.isfinite(times_rv)
         if not np.any(finite_mask):
             return

--- a/tests/unittests/jaxttv/test_jaxttv.py
+++ b/tests/unittests/jaxttv/test_jaxttv.py
@@ -1,4 +1,5 @@
 import numpy as np
+import jax
 import jax.numpy as jnp
 import importlib_resources
 import pytest
@@ -130,6 +131,26 @@ def test_get_transit_times_and_rvs_obs_times_rv_outside_range_raises(side):
 
     with pytest.raises(ValueError, match="times_rv.*valid integration range"):
         jttv.get_transit_times_and_rvs_obs(pdic, np.array([time_rv]))
+
+
+def test_get_transit_times_and_rvs_obs_traced_times_rv_skips_validation():
+    """times_rv is a JAX tracer whenever the caller sits inside a traced
+    function, as it does when a numpyro model is traced for inference. The range
+    check can only inspect concrete values, so it must be skipped in that case
+    rather than raising TracerArrayConversionError.
+    """
+    jttv, _, _, pdic = read_testdata_tc()
+    times_rv = np.linspace(jttv.t_start + 5, jttv.t_end - 5, 16)
+
+    def rvs(t):
+        _, rv, _ = jttv.get_transit_times_and_rvs_obs(pdic, t)
+        return rv
+
+    rv_traced = jax.jit(rvs)(jnp.asarray(times_rv))
+    rv_concrete = rvs(times_rv)
+
+    assert np.all(np.isfinite(rv_traced))
+    assert np.allclose(rv_traced, rv_concrete, rtol=0, atol=1e-8)
 
 
 def test_rv_from_xvjac_out_of_range_times_return_nan():


### PR DESCRIPTION
`get_transit_times_and_rvs_obs` raises `TracerArrayConversionError` when
called from inside a traced function, so it cannot be used in a numpyro
model. Small change: catch that error in `_validate_times_rv` and skip the
check.

## Why

#43 moved the range check onto an unjitted public wrapper, which starts
with `np.asarray(times_rv)`. That is fine for a concrete array, but a
traced caller passes a tracer and the conversion fails before the jitted
inner function is reached. Before #43 the public method was itself jitted,
so tracers passed straight through.

Skipping the check under tracing does not bring back the silent
extrapolation #39 reported. #43 also set `left=jnp.nan, right=jnp.nan` in
`rv_from_xvjac`, so out-of-range times give NaN on the jitted path either
way. The wrapper check is an earlier, friendlier error for concrete input,
not the only line of defense.

Concrete callers are unaffected, including the existing parametrized test
for out-of-range input. The alternative, moving the check inside the
jitted function as a value-dependent error, needs a checkify-style
mechanism and would change the calling convention for everyone.

`_validate_times_rv` lives on `Nbody`, so this covers the `NbodyRV` and
`NbodyTransit` call sites as well.

## Testing

- New test jits the call and compares the result against the
  concrete-input result. Fails without the patch with
  `TracerArrayConversionError`, passes with it.
- Full suite: 33 passed.

Found while using jnkepler for N-body RV fitting, where every call sits
inside a traced numpyro model.
